### PR TITLE
Icon System Improvements

### DIFF
--- a/images/k8s/package-dark.svg
+++ b/images/k8s/package-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16.5 9.4l-9-5.19M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+  <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+  <line x1="12" y1="22.08" x2="12" y2="12"></line>
+</svg>

--- a/images/k8s/package-light.svg
+++ b/images/k8s/package-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16.5 9.4l-9-5.19M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+  <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+  <line x1="12" y1="22.08" x2="12" y2="12"></line>
+</svg>

--- a/src/chartProfilesProvider.ts
+++ b/src/chartProfilesProvider.ts
@@ -2,350 +2,380 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { findHelmCharts, type HelmChart } from "./helmChart";
-import { getIconUris, hasIcon } from "./iconManager";
+import { getIconUris, hasIcon, getNormalizedIconName } from "./iconManager";
 
 export class ChartProfilesProvider implements vscode.TreeDataProvider<ChartTreeItem> {
-	private _onDidChangeTreeData: vscode.EventEmitter<ChartTreeItem | undefined | null> = new vscode.EventEmitter<
-		ChartTreeItem | undefined | null
-	>();
-	readonly onDidChangeTreeData: vscode.Event<ChartTreeItem | undefined | null> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    ChartTreeItem | undefined | null
+  > = new vscode.EventEmitter<ChartTreeItem | undefined | null>();
+  readonly onDidChangeTreeData: vscode.Event<ChartTreeItem | undefined | null> =
+    this._onDidChangeTreeData.event;
 
-	constructor(private workspaceRoots: string[]) {}
+  constructor(private workspaceRoots: string[]) {}
 
-	updateWorkspaceRoots(newRoots: string[]): void {
-		this.workspaceRoots = newRoots;
-	}
+  updateWorkspaceRoots(newRoots: string[]): void {
+    this.workspaceRoots = newRoots;
+  }
 
-	refresh(): void {
-		this._onDidChangeTreeData.fire(null);
-	}
+  refresh(): void {
+    this._onDidChangeTreeData.fire(null);
+  }
 
-	getTreeItem(element: ChartTreeItem): vscode.TreeItem {
-		return element;
-	}
+  getTreeItem(element: ChartTreeItem): vscode.TreeItem {
+    return element;
+  }
 
-	async getChildren(element?: ChartTreeItem): Promise<ChartTreeItem[]> {
-		if (this.workspaceRoots.length === 0) {
-			vscode.window.showInformationMessage("No workspace folder open");
-			return [];
-		}
+  async getChildren(element?: ChartTreeItem): Promise<ChartTreeItem[]> {
+    if (this.workspaceRoots.length === 0) {
+      vscode.window.showInformationMessage("No workspace folder open");
+      return [];
+    }
 
-		if (!element) {
-			// Root level: show charts from all workspace roots
-			const charts = await findHelmCharts(this.workspaceRoots);
-			return charts.map(
-				(chart) =>
-					new ChartTreeItem(chart.name, chart.path, vscode.TreeItemCollapsibleState.Expanded, "chart", chart)
-			);
-		} else if (element.type === "chart") {
-			// Chart level: show environments
-			const environments = this.getEnvironments(element.chart!);
-			return environments.map(
-				(env) =>
-					new ChartTreeItem(
-						env,
-						element.chart!.path,
-						vscode.TreeItemCollapsibleState.Collapsed,
-						"environment",
-						element.chart,
-						env
-					)
-			);
-		} else if (element.type === "environment") {
-			// Environment level: show actions
-			return [
-				new ChartTreeItem(
-					"Visualize Chart",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"visualize"
-				),
-				new ChartTreeItem(
-					"View Merged Values",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"values"
-				),
-				new ChartTreeItem(
-					"View Rendered YAML",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"rendered"
-				),
-				new ChartTreeItem(
-					"Validate Chart",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"validate"
-				),
-				new ChartTreeItem(
-					"Check Runtime State",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"runtime"
-				),
-				new ChartTreeItem(
-					"View Dependencies",
-					element.chart!.path,
-					vscode.TreeItemCollapsibleState.None,
-					"action",
-					element.chart,
-					element.environment,
-					"dependencies"
-				),
-			];
-		}
+    if (!element) {
+      // Root level: show charts from all workspace roots
+      const charts = await findHelmCharts(this.workspaceRoots);
+      return charts.map(
+        (chart) =>
+          new ChartTreeItem(
+            chart.name,
+            chart.path,
+            vscode.TreeItemCollapsibleState.Expanded,
+            "chart",
+            chart,
+          ),
+      );
+    } else if (element.type === "chart") {
+      // Chart level: show environments
+      const environments = this.getEnvironments(element.chart!);
+      return environments.map(
+        (env) =>
+          new ChartTreeItem(
+            env,
+            element.chart!.path,
+            vscode.TreeItemCollapsibleState.Collapsed,
+            "environment",
+            element.chart,
+            env,
+          ),
+      );
+    } else if (element.type === "environment") {
+      // Environment level: show actions
+      return [
+        new ChartTreeItem(
+          "Visualize Chart",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "visualize",
+        ),
+        new ChartTreeItem(
+          "View Merged Values",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "values",
+        ),
+        new ChartTreeItem(
+          "View Rendered YAML",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "rendered",
+        ),
+        new ChartTreeItem(
+          "Validate Chart",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "validate",
+        ),
+        new ChartTreeItem(
+          "Check Runtime State",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "runtime",
+        ),
+        new ChartTreeItem(
+          "View Dependencies",
+          element.chart!.path,
+          vscode.TreeItemCollapsibleState.None,
+          "action",
+          element.chart,
+          element.environment,
+          "dependencies",
+        ),
+      ];
+    }
 
-		return [];
-	}
+    return [];
+  }
 
-	private getEnvironments(chart: HelmChart): string[] {
-		const foundEnvs: string[] = [];
+  private getEnvironments(chart: HelmChart): string[] {
+    const foundEnvs: string[] = [];
 
-		try {
-			// Dynamically discover all values-*.yaml files
-			const files = fs.readdirSync(chart.path);
-			const valuesPattern = /^values-(.+)\.ya?ml$/;
+    try {
+      // Dynamically discover all values-*.yaml files
+      const files = fs.readdirSync(chart.path);
+      const valuesPattern = /^values-(.+)\.ya?ml$/;
 
-			for (const file of files) {
-				const match = file.match(valuesPattern);
-				if (match && match[1]) {
-					foundEnvs.push(match[1]);
-				}
-			}
-		} catch (error) {
-			console.error(`Error reading chart directory ${chart.path}:`, error);
-		}
+      for (const file of files) {
+        const match = file.match(valuesPattern);
+        if (match && match[1]) {
+          foundEnvs.push(match[1]);
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading chart directory ${chart.path}:`, error);
+    }
 
-		// Sort environments alphabetically for stable ordering
-		foundEnvs.sort();
+    // Sort environments alphabetically for stable ordering
+    foundEnvs.sort();
 
-		// Always include base if no specific environments found
-		return foundEnvs.length > 0 ? foundEnvs : ["default"];
-	}
+    // Always include base if no specific environments found
+    return foundEnvs.length > 0 ? foundEnvs : ["default"];
+  }
 }
 
 export class ChartTreeItem extends vscode.TreeItem {
-	private _hasOverrides?: boolean;
+  private _hasOverrides?: boolean;
 
-	constructor(
-		public readonly label: string,
-		public readonly chartPath: string,
-		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-		public readonly type: "chart" | "environment" | "action",
-		public readonly chart?: HelmChart,
-		public readonly environment?: string,
-		public readonly action?: "values" | "rendered" | "visualize" | "validate" | "runtime" | "dependencies"
-	) {
-		super(label, collapsibleState);
+  constructor(
+    public readonly label: string,
+    public readonly chartPath: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly type: "chart" | "environment" | "action",
+    public readonly chart?: HelmChart,
+    public readonly environment?: string,
+    public readonly action?:
+      | "values"
+      | "rendered"
+      | "visualize"
+      | "validate"
+      | "runtime"
+      | "dependencies",
+  ) {
+    super(label, collapsibleState);
 
-		// Cache hasOverrides calculation for environment nodes
-		if (type === "environment") {
-			this._hasOverrides = this.calculateHasEnvironmentOverrides();
-		}
+    // Cache hasOverrides calculation for environment nodes
+    if (type === "environment") {
+      this._hasOverrides = this.calculateHasEnvironmentOverrides();
+    }
 
-		this.tooltip = this.getTooltip();
-		// Add more specific context values for future context menu support
-		this.contextValue = this.getContextValue();
-		this.iconPath = this.getIcon();
-		this.description = this.getDescription();
+    this.tooltip = this.getTooltip();
+    // Add more specific context values for future context menu support
+    this.contextValue = this.getContextValue();
+    this.iconPath = this.getIcon();
+    this.description = this.getDescription();
 
-		if (type === "action") {
-			if (action === "visualize") {
-				this.command = {
-					command: "chartProfiles.visualizeChart",
-					title: "Visualize",
-					arguments: [this],
-				};
-			} else if (action === "validate") {
-				this.command = {
-					command: "chartProfiles.validateChart",
-					title: "Validate",
-					arguments: [this],
-				};
-			} else if (action === "runtime") {
-				this.command = {
-					command: "chartProfiles.checkRuntimeState",
-					title: "Check Runtime",
-					arguments: [this],
-				};
-			} else if (action === "dependencies") {
-				this.command = {
-					command: "chartProfiles.viewDependencies",
-					title: "View Dependencies",
-					arguments: [this],
-				};
-			} else {
-				this.command = {
-					command: "chartProfiles.viewRenderedYaml",
-					title: "View",
-					arguments: [this],
-				};
-			}
-		}
-	}
+    if (type === "action") {
+      if (action === "visualize") {
+        this.command = {
+          command: "chartProfiles.visualizeChart",
+          title: "Visualize",
+          arguments: [this],
+        };
+      } else if (action === "validate") {
+        this.command = {
+          command: "chartProfiles.validateChart",
+          title: "Validate",
+          arguments: [this],
+        };
+      } else if (action === "runtime") {
+        this.command = {
+          command: "chartProfiles.checkRuntimeState",
+          title: "Check Runtime",
+          arguments: [this],
+        };
+      } else if (action === "dependencies") {
+        this.command = {
+          command: "chartProfiles.viewDependencies",
+          title: "View Dependencies",
+          arguments: [this],
+        };
+      } else {
+        this.command = {
+          command: "chartProfiles.viewRenderedYaml",
+          title: "View",
+          arguments: [this],
+        };
+      }
+    }
+  }
 
-	private getContextValue(): string {
-		if (this.type === "chart") {
-			return "chart";
-		} else if (this.type === "environment") {
-			// Use cached value (should always be defined for environment nodes)
-			return (this._hasOverrides ?? false) ? "environment" : "environment-no-overrides";
-		} else if (this.type === "action") {
-			return `action-${this.action}`;
-		}
-		return this.type;
-	}
+  private getContextValue(): string {
+    if (this.type === "chart") {
+      return "chart";
+    } else if (this.type === "environment") {
+      // Use cached value (should always be defined for environment nodes)
+      return (this._hasOverrides ?? false)
+        ? "environment"
+        : "environment-no-overrides";
+    } else if (this.type === "action") {
+      return `action-${this.action}`;
+    }
+    return this.type;
+  }
 
-	private calculateHasEnvironmentOverrides(): boolean {
-		if (!this.chart || !this.environment || this.environment === "default") {
-			return false;
-		}
+  private calculateHasEnvironmentOverrides(): boolean {
+    if (!this.chart || !this.environment || this.environment === "default") {
+      return false;
+    }
 
-		const envValuesPath = path.join(this.chart.path, `values-${this.environment}.yaml`);
-		try {
-			if (fs.existsSync(envValuesPath)) {
-				const content = fs.readFileSync(envValuesPath, "utf8");
-				// Check if file has meaningful content (not just comments/whitespace)
-				const lines = content.split("\n");
-				for (const line of lines) {
-					const trimmed = line.trim();
-					if (trimmed && !trimmed.startsWith("#")) {
-						return true;
-					}
-				}
-				return false;
-			}
-		} catch (error) {
-			console.error(`Error checking overrides for ${envValuesPath}:`, error);
-		}
-		return false;
-	}
+    const envValuesPath = path.join(
+      this.chart.path,
+      `values-${this.environment}.yaml`,
+    );
+    try {
+      if (fs.existsSync(envValuesPath)) {
+        const content = fs.readFileSync(envValuesPath, "utf8");
+        // Check if file has meaningful content (not just comments/whitespace)
+        const lines = content.split("\n");
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed && !trimmed.startsWith("#")) {
+            return true;
+          }
+        }
+        return false;
+      }
+    } catch (error) {
+      console.error(`Error checking overrides for ${envValuesPath}:`, error);
+    }
+    return false;
+  }
 
-	private getDescription(): string | undefined {
-		if (this.type === "environment") {
-			// Use cached value
-			const hasOverrides = this._hasOverrides ?? false;
-			if (!hasOverrides && this.environment !== "default") {
-				return "(no overrides)";
-			}
-		}
-		return undefined;
-	}
+  private getDescription(): string | undefined {
+    if (this.type === "environment") {
+      // Use cached value
+      const hasOverrides = this._hasOverrides ?? false;
+      if (!hasOverrides && this.environment !== "default") {
+        return "(no overrides)";
+      }
+    }
+    return undefined;
+  }
 
-	private getTooltip(): string | vscode.MarkdownString {
-		if (this.type === "chart") {
-			const tooltip = new vscode.MarkdownString();
-			tooltip.appendMarkdown(`**Helm Chart:** ${this.label}\n\n`);
-			tooltip.appendMarkdown(`**Path:** \`${this.chartPath}\`\n\n`);
-			if (this.chart?.version) {
-				tooltip.appendMarkdown(`**Version:** ${this.chart.version}\n\n`);
-			}
-			if (this.chart?.description) {
-				tooltip.appendMarkdown(`**Description:** ${this.chart.description}\n\n`);
-			}
-			return tooltip;
-		} else if (this.type === "environment") {
-			const tooltip = new vscode.MarkdownString();
-			tooltip.appendMarkdown(`**Environment:** ${this.environment}\n\n`);
+  private getTooltip(): string | vscode.MarkdownString {
+    if (this.type === "chart") {
+      const tooltip = new vscode.MarkdownString();
+      tooltip.appendMarkdown(`**Helm Chart:** ${this.label}\n\n`);
+      tooltip.appendMarkdown(`**Path:** \`${this.chartPath}\`\n\n`);
+      if (this.chart?.version) {
+        tooltip.appendMarkdown(`**Version:** ${this.chart.version}\n\n`);
+      }
+      if (this.chart?.description) {
+        tooltip.appendMarkdown(
+          `**Description:** ${this.chart.description}\n\n`,
+        );
+      }
+      return tooltip;
+    } else if (this.type === "environment") {
+      const tooltip = new vscode.MarkdownString();
+      tooltip.appendMarkdown(`**Environment:** ${this.environment}\n\n`);
 
-			// Show which values file is used
-			if (this.environment === "default") {
-				tooltip.appendMarkdown(`**Values file:** \`values.yaml\` (base only)\n\n`);
-			} else {
-				const envValuesPath = path.join(this.chartPath, `values-${this.environment}.yaml`);
-				const envValuesExists = fs.existsSync(envValuesPath);
+      // Show which values file is used
+      if (this.environment === "default") {
+        tooltip.appendMarkdown(
+          `**Values file:** \`values.yaml\` (base only)\n\n`,
+        );
+      } else {
+        const envValuesPath = path.join(
+          this.chartPath,
+          `values-${this.environment}.yaml`,
+        );
+        const envValuesExists = fs.existsSync(envValuesPath);
 
-				if (envValuesExists) {
-					tooltip.appendMarkdown(`**Values files:**\n`);
-					tooltip.appendMarkdown(`- \`values.yaml\` (base)\n`);
-					tooltip.appendMarkdown(`- \`values-${this.environment}.yaml\` (overrides)\n\n`);
+        if (envValuesExists) {
+          tooltip.appendMarkdown(`**Values files:**\n`);
+          tooltip.appendMarkdown(`- \`values.yaml\` (base)\n`);
+          tooltip.appendMarkdown(
+            `- \`values-${this.environment}.yaml\` (overrides)\n\n`,
+          );
 
-					// Use cached value
-					const hasOverrides = this._hasOverrides ?? false;
-					if (!hasOverrides) {
-						tooltip.appendMarkdown(`⚠️ *Environment file exists but contains no overrides*\n\n`);
-					}
-				} else {
-					tooltip.appendMarkdown(`**Values file:** \`values.yaml\` (base only)\n\n`);
-				}
-			}
+          // Use cached value
+          const hasOverrides = this._hasOverrides ?? false;
+          if (!hasOverrides) {
+            tooltip.appendMarkdown(
+              `⚠️ *Environment file exists but contains no overrides*\n\n`,
+            );
+          }
+        } else {
+          tooltip.appendMarkdown(
+            `**Values file:** \`values.yaml\` (base only)\n\n`,
+          );
+        }
+      }
 
-			return tooltip;
-		} else if (this.action === "visualize") {
-			return `Visualize chart statistics and resource distribution for ${this.environment} environment`;
-		} else if (this.action === "values") {
-			return `View merged values from base and ${this.environment}-specific files`;
-		} else if (this.action === "rendered") {
-			return `View rendered YAML templates for ${this.environment} environment using Helm CLI`;
-		} else if (this.action === "validate") {
-			return `Validate chart configuration and check for best practices`;
-		} else if (this.action === "runtime") {
-			return `Check runtime state of deployed resources in ${this.environment} environment`;
-		} else if (this.action === "dependencies") {
-			return `View chart dependencies and check for security issues`;
-		}
-		return this.label;
-	}
+      return tooltip;
+    } else if (this.action === "visualize") {
+      return `Visualize chart statistics and resource distribution for ${this.environment} environment`;
+    } else if (this.action === "values") {
+      return `View merged values from base and ${this.environment}-specific files`;
+    } else if (this.action === "rendered") {
+      return `View rendered YAML templates for ${this.environment} environment using Helm CLI`;
+    } else if (this.action === "validate") {
+      return `Validate chart configuration and check for best practices`;
+    } else if (this.action === "runtime") {
+      return `Check runtime state of deployed resources in ${this.environment} environment`;
+    } else if (this.action === "dependencies") {
+      return `View chart dependencies and check for security issues`;
+    }
+    return this.label;
+  }
 
-	private getIcon(): vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri } {
-		if (this.type === "chart") {
-			// Use custom package icon if available, otherwise fall back to theme icon
-			if (hasIcon("package")) {
-				return getIconUris("package");
-			}
-			return new vscode.ThemeIcon("package");
-		} else if (this.type === "environment") {
-			// Add visual indicator for environments with no overrides
-			const hasOverrides = this._hasOverrides ?? false;
-			if (!hasOverrides && this.environment !== "default") {
-				return new vscode.ThemeIcon("circle-outline"); // hollow icon for no overrides
-			}
-			// Use custom environment icon
-			if (hasIcon("namespace")) {
-				return getIconUris("namespace");
-			}
-			return new vscode.ThemeIcon("server-environment");
-		} else if (this.action === "visualize") {
-			// Use custom graph/topology icon
-			if (hasIcon("networkpolicy")) {
-				return getIconUris("networkpolicy");
-			}
-			return new vscode.ThemeIcon("graph");
-		} else if (this.action === "values") {
-			// Use configmap icon for values
-			if (hasIcon("configmap")) {
-				return getIconUris("configmap");
-			}
-			return new vscode.ThemeIcon("file-code");
-		} else if (this.action === "rendered") {
-			// Use deployment icon for rendered output
-			if (hasIcon("deployment")) {
-				return getIconUris("deployment");
-			}
-			return new vscode.ThemeIcon("output");
-		} else if (this.action === "validate") {
-			return new vscode.ThemeIcon("check");
-		} else if (this.action === "runtime") {
-			return new vscode.ThemeIcon("pulse");
-		} else if (this.action === "dependencies") {
-			return new vscode.ThemeIcon("type-hierarchy");
-		}
-		return new vscode.ThemeIcon("file");
-	}
+  private getIcon():
+    | vscode.ThemeIcon
+    | { light: vscode.Uri; dark: vscode.Uri } {
+    // Helper function to get icon with fallback using normalized name
+    const getCustomIcon = (
+      kind: string,
+    ): vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri } => {
+      const normalizedKind = getNormalizedIconName(kind);
+      if (hasIcon(normalizedKind)) {
+        return getIconUris(normalizedKind);
+      }
+      // Return VS Code theme icon as fallback
+      return new vscode.ThemeIcon(kind.toLowerCase());
+    };
+
+    if (this.type === "chart") {
+      // Use custom package icon for Helm charts
+      return getCustomIcon("package");
+    } else if (this.type === "environment") {
+      // Add visual indicator for environments with no overrides
+      const hasOverrides = this._hasOverrides ?? false;
+      if (!hasOverrides && this.environment !== "default") {
+        return new vscode.ThemeIcon("circle-outline"); // hollow icon for no overrides
+      }
+      // Use namespace icon for environments
+      return getCustomIcon("namespace");
+    } else if (this.action === "visualize") {
+      // Use deployment/graph icon for visualize action
+      return getCustomIcon("deployment");
+    } else if (this.action === "values") {
+      // Use configmap icon for values
+      return getCustomIcon("configmap");
+    } else if (this.action === "rendered") {
+      // Use deployment icon for rendered output
+      return getCustomIcon("deployment");
+    } else if (this.action === "validate") {
+      return new vscode.ThemeIcon("check");
+    } else if (this.action === "runtime") {
+      return new vscode.ThemeIcon("pulse");
+    } else if (this.action === "dependencies") {
+      return new vscode.ThemeIcon("type-hierarchy");
+    }
+    return new vscode.ThemeIcon("file");
+  }
 }

--- a/src/iconManager.ts
+++ b/src/iconManager.ts
@@ -38,7 +38,9 @@ export function getIconPath(
   theme: "dark" | "light" = "dark",
 ): string {
   if (!extensionContext) {
-    throw new Error("Icon manager not initialized. Call initializeIconManager() first.");
+    throw new Error(
+      "Icon manager not initialized. Call initializeIconManager() first.",
+    );
   }
   const iconName = getIconFileName(kind);
   const fileName = `${iconName}-${theme}.svg`;
@@ -53,7 +55,9 @@ export function getIconUri(
   theme: "dark" | "light" = "dark",
 ): vscode.Uri {
   if (!extensionContext) {
-    throw new Error("Icon manager not initialized. Call initializeIconManager() first.");
+    throw new Error(
+      "Icon manager not initialized. Call initializeIconManager() first.",
+    );
   }
   const iconName = getIconFileName(kind);
   const fileName = `${iconName}-${theme}.svg`;
@@ -237,45 +241,115 @@ export function getAvailableIconKinds(): string[] {
 export const KIND_ICON_MAP: Record<string, string> = {
   // Workloads
   Deployment: "deployment",
+  Deployments: "deployment",
   StatefulSet: "statefulset",
+  StatefulSets: "statefulset",
   DaemonSet: "daemonset",
+  DaemonSets: "daemonset",
   ReplicaSet: "replicaset",
+  ReplicaSets: "replicaset",
   Pod: "pod",
+  Pods: "pod",
   Job: "job",
+  Jobs: "job",
   CronJob: "cronjob",
+  CronJobs: "cronjob",
 
   // Networking
   Service: "service",
+  Services: "service",
   Ingress: "ingress",
+  Ingresses: "ingress",
   NetworkPolicy: "networkpolicy",
+  NetworkPolicies: "networkpolicy",
+  Endpoint: "service",
+  Endpoints: "service",
+  EndpointSlice: "service",
+  EndpointSlices: "service",
 
   // Configuration
   ConfigMap: "configmap",
+  ConfigMaps: "configmap",
   Secret: "secret",
+  Secrets: "secret",
 
   // Storage
   PersistentVolume: "persistentvolume",
+  PersistentVolumes: "persistentvolume",
   PersistentVolumeClaim: "persistentvolumeclaim",
+  PersistentVolumeClaims: "persistentvolumeclaim",
+  StorageClass: "persistentvolume",
+  StorageClasses: "persistentvolume",
 
   // RBAC
   Role: "role",
+  Roles: "role",
   RoleBinding: "rolebinding",
+  RoleBindings: "rolebinding",
   ClusterRole: "clusterrole",
   ClusterRoleBinding: "clusterrolebinding",
+  ClusterRoleBindings: "clusterrolebinding",
   ServiceAccount: "serviceaccount",
+  ServiceAccounts: "serviceaccount",
 
   // Scaling
   HorizontalPodAutoscaler: "horizontalpodautoscaler",
+  HorizontalPodAutoscalers: "horizontalpodautoscaler",
 
   // Other
   Namespace: "namespace",
+  Namespaces: "namespace",
+  Node: "pod",
+  Nodes: "pod",
+  Event: "pod",
+  Events: "pod",
+
+  // Helm-specific
+  Package: "package",
+  HelmChart: "package",
+  Chart: "package",
 };
 
 /**
  * Get the normalized icon name for a Kubernetes kind
+ * Handles plural forms, different casings, and provides fallback
  */
 export function getNormalizedIconName(kind: string): string {
-  return KIND_ICON_MAP[kind] || getIconFileName(kind);
+  // First try exact match
+  if (KIND_ICON_MAP[kind]) {
+    return KIND_ICON_MAP[kind];
+  }
+
+  // Try singular form (remove trailing 's')
+  if (kind.endsWith("s") && KIND_ICON_MAP[kind.slice(0, -1)]) {
+    return KIND_ICON_MAP[kind.slice(0, -1)];
+  }
+
+  // Try with first letter lowercase
+  const lowerKind = kind.charAt(0).toLowerCase() + kind.slice(1);
+  if (KIND_ICON_MAP[lowerKind]) {
+    return KIND_ICON_MAP[lowerKind];
+  }
+
+  // Fall back to file name conversion
+  return getIconFileName(kind);
+}
+
+/**
+ * Get fallback icon based on category
+ * Used when no specific icon exists for a resource kind
+ */
+export function getFallbackIconByCategory(category: string): string {
+  const categoryIcons: Record<string, string> = {
+    Workload: "deployment",
+    Networking: "service",
+    Storage: "persistentvolume",
+    Configuration: "configmap",
+    RBAC: "role",
+    Scaling: "horizontalpodautoscaler",
+    Other: "deployment",
+  };
+  return categoryIcons[category] || "deployment";
 }
 
 /**
@@ -290,4 +364,37 @@ export function hasIcon(kind: string): boolean {
     `${iconName}-dark.svg`,
   );
   return fs.existsSync(darkPath);
+}
+
+/**
+ * Get icon data URI with automatic fallback
+ * If icon doesn't exist for the given kind, falls back to category-based icon
+ */
+export function getIconDataUriWithFallback(
+  kind: string,
+  category: string,
+  theme: "dark" | "light" = "dark",
+): string {
+  try {
+    const normalizedKind = getNormalizedIconName(kind);
+    // Try to get the specific icon
+    if (hasIcon(normalizedKind)) {
+      return getIconDataUri(normalizedKind, theme);
+    }
+  } catch (error) {
+    console.warn(`Failed to get icon for ${kind}, trying fallback:`, error);
+  }
+
+  // Fallback to category-based icon
+  const fallbackIcon = getFallbackIconByCategory(category);
+  try {
+    return getIconDataUri(fallbackIcon, theme);
+  } catch (error) {
+    console.warn(
+      `Failed to get fallback icon for category ${category}:`,
+      error,
+    );
+    // Ultimate fallback - return empty string, CSS will handle display
+    return "";
+  }
 }

--- a/src/webviewHtmlGenerator.ts
+++ b/src/webviewHtmlGenerator.ts
@@ -2,70 +2,88 @@ import * as crypto from "node:crypto";
 import * as yaml from "js-yaml";
 import * as vscode from "vscode";
 import type { ResourceHierarchy } from "./resourceVisualizer";
-import { getIconDataUri, getNormalizedIconName } from "./iconManager";
+import {
+  getIconDataUri,
+  getNormalizedIconName,
+  getIconDataUriWithFallback,
+} from "./iconManager";
 
 /**
  * Interface for Kubernetes Secret object structure
  */
 interface SecretObject {
-	data?: Record<string, string>;
-	stringData?: Record<string, string>;
-	[key: string]: any;
+  data?: Record<string, string>;
+  stringData?: Record<string, string>;
+  [key: string]: any;
 }
 
 /**
  * Sanitize a Secret's YAML content by redacting sensitive data fields
  */
 function sanitizeSecretYaml(yamlContent: string): string {
-	try {
-		const yamlObj = yaml.load(yamlContent.replace(/^#.*$/gm, "").trim());
+  try {
+    const yamlObj = yaml.load(yamlContent.replace(/^#.*$/gm, "").trim());
 
-		// Type guard to ensure we have a valid object
-		if (!yamlObj || typeof yamlObj !== "object") {
-			return "# Secret data redacted for security";
-		}
+    // Type guard to ensure we have a valid object
+    if (!yamlObj || typeof yamlObj !== "object") {
+      return "# Secret data redacted for security";
+    }
 
-		const secretObj = yamlObj as SecretObject;
+    const secretObj = yamlObj as SecretObject;
 
-		// Redact sensitive fields by replacing values with placeholders
-		const redactField = (obj: Record<string, string>): Record<string, string> => {
-			return Object.keys(obj).reduce(
-				(acc, key) => {
-					acc[key] = "***REDACTED***";
-					return acc;
-				},
-				{} as Record<string, string>
-			);
-		};
+    // Redact sensitive fields by replacing values with placeholders
+    const redactField = (
+      obj: Record<string, string>,
+    ): Record<string, string> => {
+      return Object.keys(obj).reduce(
+        (acc, key) => {
+          acc[key] = "***REDACTED***";
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+    };
 
-		if (secretObj.data) {
-			secretObj.data = redactField(secretObj.data);
-		}
-		if (secretObj.stringData) {
-			secretObj.stringData = redactField(secretObj.stringData);
-		}
+    if (secretObj.data) {
+      secretObj.data = redactField(secretObj.data);
+    }
+    if (secretObj.stringData) {
+      secretObj.stringData = redactField(secretObj.stringData);
+    }
 
-		return yaml.dump(secretObj);
-	} catch (error) {
-		// If parsing fails, just hide the whole yaml for secrets
-		return "# Secret data redacted for security";
-	}
+    return yaml.dump(secretObj);
+  } catch (error) {
+    // If parsing fails, just hide the whole yaml for secrets
+    return "# Secret data redacted for security";
+  }
 }
 
 /**
  * Generate enhanced webview HTML with resource explorer, topology view, and interactive features
  */
-export function generateEnhancedHtml(webview: vscode.Webview, data: any, extensionUri: vscode.Uri): string {
-	const nonce = getNonce();
+export function generateEnhancedHtml(
+  webview: vscode.Webview,
+  data: any,
+  extensionUri: vscode.Uri,
+): string {
+  const nonce = getNonce();
 
-	// Get local Chart.js and CSS URIs
-	const chartJsUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, "vendor", "chart.umd.js"));
-	const stylesUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, "out", "styles.css"));
+  // Get local Chart.js and CSS URIs
+  const chartJsUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "vendor", "chart.umd.js"),
+  );
+  const stylesUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "out", "styles.css"),
+  );
 
-	// Generate resource explorer HTML
-	const resourceExplorerHtml = generateResourceExplorer(data.resourceHierarchy, webview, extensionUri);
+  // Generate resource explorer HTML
+  const resourceExplorerHtml = generateResourceExplorer(
+    data.resourceHierarchy,
+    webview,
+    extensionUri,
+  );
 
-	return `<!DOCTYPE html>
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -103,7 +121,7 @@ export function generateEnhancedHtml(webview: vscode.Webview, data: any, extensi
 }
 
 function generateOverviewTab(data: any): string {
-	return `
+  return `
         <div class="header">
             <h1 class="chart-title">
                 ${escapeHtml(data.chartName)}
@@ -114,8 +132,8 @@ function generateOverviewTab(data: any): string {
         ${generateTopologyTab()}
 
         ${
-			data.overriddenValues.length > 0
-				? `
+          data.overriddenValues.length > 0
+            ? `
         <div class="chart-container">
             <h2>Overridden Values</h2>
             <div class="stats-container">
@@ -146,21 +164,21 @@ function generateOverviewTab(data: any): string {
                 </thead>
                 <tbody>
                     ${data.overriddenValues
-						.map(
-							(v: any) => `
+                      .map(
+                        (v: any) => `
                         <tr>
                             <td class="value-key">${escapeHtml(v.key)}</td>
                             <td class="value-old">${escapeHtml(formatValue(v.baseValue))}</td>
                             <td class="value-new">${escapeHtml(formatValue(v.envValue))}</td>
                         </tr>
-                    `
-						)
-						.join("")}
+                    `,
+                      )
+                      .join("")}
                 </tbody>
             </table>
         </div>
         `
-				: `
+            : `
         <div class="chart-container">
             <div class="stats-container">
                 <div class="stat-card">
@@ -182,27 +200,27 @@ function generateOverviewTab(data: any): string {
             </div>
         </div>
         `
-		}
+        }
     `;
 }
 
 function generateResourceExplorer(
-	hierarchy: ResourceHierarchy,
-	webview: vscode.Webview,
-	extensionUri: vscode.Uri
+  hierarchy: ResourceHierarchy,
+  webview: vscode.Webview,
+  extensionUri: vscode.Uri,
 ): string {
-	if (!hierarchy || hierarchy.totalCount === 0) {
-		return '<div class="no-data"><p>No resources found</p></div>';
-	}
+  if (!hierarchy || hierarchy.totalCount === 0) {
+    return '<div class="no-data"><p>No resources found</p></div>';
+  }
 
-	let html = '<div class="resource-explorer">';
+  let html = '<div class="resource-explorer">';
 
-	for (const [kind, group] of hierarchy.kindGroups) {
-		// Get icon for this resource kind
-		const iconName = getNormalizedIconName(kind);
-		const iconDataUri = getIconDataUri(kind, "dark");
+  for (const [kind, group] of hierarchy.kindGroups) {
+    // Get icon for this resource kind
+    const iconName = getNormalizedIconName(kind);
+    const iconDataUri = getIconDataUri(kind, "dark");
 
-		html += `
+    html += `
         <div class="kind-group" data-kind="${escapeHtml(kind)}">
             <div class="kind-header">
                 <span class="expand-icon">▶</span>
@@ -212,14 +230,17 @@ function generateResourceExplorer(
             <div class="kind-resources" data-collapsed="true">
         `;
 
-		for (const resource of group.resources) {
-			// For secrets, sanitize the YAML to mask sensitive data
-			const displayYaml = resource.kind === "Secret" ? sanitizeSecretYaml(resource.yaml) : resource.yaml;
+    for (const resource of group.resources) {
+      // For secrets, sanitize the YAML to mask sensitive data
+      const displayYaml =
+        resource.kind === "Secret"
+          ? sanitizeSecretYaml(resource.yaml)
+          : resource.yaml;
 
-			// Get icon for this resource
-			const resourceIconUri = getIconDataUri(resource.kind, "dark");
+      // Get icon for this resource
+      const resourceIconUri = getIconDataUri(resource.kind, "dark");
 
-			html += `
+      html += `
             <div class="resource-card" data-color="${group.colorCode}" data-resource-name="${escapeAttr(resource.name)}">
                 <div class="resource-header">
                     <span class="expand-icon">▶</span>
@@ -234,25 +255,25 @@ function generateResourceExplorer(
                         <pre>${escapeHtml(JSON.stringify(resource.metadata, null, 2))}</pre>
                     </div>
                     ${
-						Object.keys(resource.spec || {}).length > 0
-							? `
+                      Object.keys(resource.spec || {}).length > 0
+                        ? `
                     <div class="detail-section">
                         <h4>Spec</h4>
                         <pre>${escapeHtml(JSON.stringify(resource.spec, null, 2))}</pre>
                     </div>
                     `
-							: ""
-					}
+                        : ""
+                    }
                     ${
-						resource.kind === "Secret" && resource.data
-							? `
+                      resource.kind === "Secret" && resource.data
+                        ? `
                     <div class="detail-section">
                         <h4>Data (masked)</h4>
                         <pre>${escapeHtml(JSON.stringify(resource.data, null, 2))}</pre>
                     </div>
                     `
-							: ""
-					}
+                        : ""
+                    }
                     <div class="detail-section">
                         <h4>Full YAML</h4>
                         <pre class="yaml-content">${escapeHtml(displayYaml)}</pre>
@@ -260,20 +281,20 @@ function generateResourceExplorer(
                 </div>
             </div>
             `;
-		}
+    }
 
-		html += `
+    html += `
             </div>
         </div>
         `;
-	}
+  }
 
-	html += "</div>";
-	return html;
+  html += "</div>";
+  return html;
 }
 
 function generateTopologyTab(): string {
-	return `
+  return `
         <div class="topology-view">
             <div class="topology-header">
                 <div class="topology-title-section">
@@ -404,28 +425,41 @@ function generateTopologyTab(): string {
 }
 
 function generateJavaScript(data: any): string {
-	// Pass architecture data safely
-	const architectureNodes = data.architectureNodes || [];
-	const relationships = data.relationships || [];
-	const safeArchNodes = JSON.stringify(architectureNodes).replace(/</g, "\\u003c");
-	const safeRelationships = JSON.stringify(relationships).replace(/</g, "\\u003c");
+  // Pass architecture data safely
+  const architectureNodes = data.architectureNodes || [];
+  const relationships = data.relationships || [];
+  const safeArchNodes = JSON.stringify(architectureNodes).replace(
+    /</g,
+    "\\u003c",
+  );
+  const safeRelationships = JSON.stringify(relationships).replace(
+    /</g,
+    "\\u003c",
+  );
 
-	// Generate icon data URIs for all unique kinds in the nodes
-	const kindIconMap: Record<string, string> = {};
-	for (const node of architectureNodes) {
-		if (node.kind && !kindIconMap[node.kind]) {
-			try {
-				kindIconMap[node.kind] = getIconDataUri(node.kind, "dark");
-			} catch (error) {
-				// If the icon manager is not initialized or an error occurs,
-				// skip assigning an icon for this kind rather than failing.
-				console.warn(`Failed to get icon for kind ${node.kind}:`, error);
-			}
-		}
-	}
-	const safeIconMap = JSON.stringify(kindIconMap).replace(/</g, "\\u003c");
+  // Generate icon data URIs for all unique kinds in the nodes
+  // Default to dark theme, webview will switch based on VS Code theme
+  // Uses category-based fallback when specific icon doesn't exist
+  const kindIconMap: Record<string, string> = {};
+  for (const node of architectureNodes) {
+    if (node.kind && !kindIconMap[node.kind]) {
+      try {
+        // Use fallback function that tries specific icon, then category-based icon
+        kindIconMap[node.kind] = getIconDataUriWithFallback(
+          node.kind,
+          node.category || "Other",
+          "dark",
+        );
+      } catch (error) {
+        // If the icon manager is not initialized or an error occurs,
+        // skip assigning an icon for this kind rather than failing.
+        console.warn(`Failed to get icon for kind ${node.kind}:`, error);
+      }
+    }
+  }
+  const safeIconMap = JSON.stringify(kindIconMap).replace(/</g, "\\u003c");
 
-	return `
+  return `
         const vscode = acquireVsCodeApi();
         let currentZoom = 1;
         let topologyZoom = 1;
@@ -1149,7 +1183,7 @@ function generateJavaScript(data: any): string {
 }
 
 function generateChartJsInit(data: any): string {
-	return `
+  return `
         const chartColors = {
             primary: '#007acc',
             secondary: '#68217a',
@@ -1169,8 +1203,8 @@ function generateChartJsInit(data: any): string {
         ];
 
         ${
-			Object.keys(data.resourceCounts || {}).length > 0
-				? `
+          Object.keys(data.resourceCounts || {}).length > 0
+            ? `
         (function() {
             const canvas = document.getElementById('resourceChart');
             if (!canvas) return;
@@ -1288,12 +1322,12 @@ function generateChartJsInit(data: any): string {
             }
         })();
         `
-				: ""
-		}
+            : ""
+        }
 
         ${
-			data.totalValues > 0
-				? `
+          data.totalValues > 0
+            ? `
         (function() {
             const ctx = document.getElementById('valuesChart');
             if (!ctx) return;
@@ -1314,37 +1348,37 @@ function generateChartJsInit(data: any): string {
             });
         })();
         `
-				: ""
-		}
+            : ""
+        }
     `;
 }
 
 function getNonce(): string {
-	return crypto.randomBytes(16).toString("base64");
+  return crypto.randomBytes(16).toString("base64");
 }
 
 /**
  * Format a value for display, handling objects and arrays properly
  */
 function formatValue(value: any): string {
-	if (value === null || value === undefined) {
-		return "(not set)";
-	}
-	if (typeof value === "object") {
-		return JSON.stringify(value);
-	}
-	return String(value);
+  if (value === null || value === undefined) {
+    return "(not set)";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
 }
 
 function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#039;");
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
 }
 
 function escapeAttr(text: string): string {
-	return text.replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+  return text.replace(/"/g, "&quot;").replace(/'/g, "&#039;");
 }


### PR DESCRIPTION
### Changes Made

#### 1. New Icon Files Created
- [`images/k8s/package-dark.svg`](images/k8s/package-dark.svg) - Package icon for Helm charts (dark theme)
- [`images/k8s/package-light.svg`](images/k8s/package-light.svg) - Package icon for Helm charts (light theme)

#### 2. Updated KIND_ICON_MAP ([`src/iconManager.ts`](src/iconManager.ts:241))
Added mapping for:
```typescript
// Helm-specific
Package: "package",
HelmChart: "package", 
Chart: "package",
```

#### 3. Enhanced getNormalizedIconName() ([`src/iconManager.ts`](src/iconManager.ts:312))
Added logic to handle:
- Exact matches
- Singular form fallback (removes trailing 's')
- Lowercase first letter fallback
- File name conversion

#### 4. New getFallbackIconByCategory() ([`src/iconManager.ts`](src/iconManager.ts:337))
Added category-based fallback icons:
- Workload → deployment
- Networking → service
- Storage → persistentvolume
- Configuration → configmap
- RBAC → role
- Scaling → horizontalpodautoscaler

#### 5. New getIconDataUriWithFallback() ([`src/iconManager.ts`](src/iconManager.ts:367))
New function that:
- Tries to get specific icon for the kind
- Falls back to category-based icon if not found
- Returns empty string as ultimate fallback

#### 6. Updated Tree View Icons ([`src/chartProfilesProvider.ts`](src/chartProfilesProvider.ts:337))
- Added `getNormalizedIconName` import
- Created helper function `getCustomIcon()` for consistent icon handling
- Uses package icon for Helm charts
- Uses namespace icon for environments
- Uses deployment icon for visualize/visualization actions

#### 7. Updated Webview Icon Generation ([`src/webviewHtmlGenerator.ts`](src/webviewHtmlGenerator.ts:440))
- Now uses `getIconDataUriWithFallback()` for all icons
- Includes category information for better fallback
- No more missing icons in Architecture/Topology views

---

### How It Works Now

1. **Tree View**: Icons are loaded using normalized names with VS Code theme fallback
2. **Architecture/Topology View**: Icons use specific kind first, then category fallback
3. **Unknown Resources**: Always show a relevant icon (never blank)

The extension now has comprehensive icon support for all Kubernetes resource types with proper fallback handling.