### PR TITLE
Fix findChartsRecursive to discover nested sub-charts (F11)

### DIFF
--- a/src/k8s/helmChart.ts
+++ b/src/k8s/helmChart.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { SKIP_DIRECTORIES } from "../utils/constants";
-import { parseYaml, type ChartYaml } from "../utils/yaml";
+import { type ChartYaml, parseYaml } from "../utils/yaml";
 
 export interface HelmChart {
 	name: string;
@@ -45,7 +45,17 @@ async function findChartsRecursive(dirPath: string, charts: HelmChart[]): Promis
 					if (chart) {
 						charts.push(chart);
 					}
-					// Don't recurse into chart directories
+					// Recurse into subdirectories to find sub-charts, but skip templates/
+					const subEntries = fs.readdirSync(fullPath, { withFileTypes: true });
+					for (const subEntry of subEntries) {
+						if (
+							subEntry.isDirectory() &&
+							subEntry.name !== "templates" &&
+							!shouldSkipDirectory(subEntry.name)
+						) {
+							await findChartsRecursive(path.join(fullPath, subEntry.name), charts);
+						}
+					}
 					continue;
 				}
 


### PR DESCRIPTION
Instead of stopping recursion entirely after finding Chart.yaml, now recurses into subdirectories (like charts/) to find nested sub-charts, while still skipping templates/ directories that contain Go templates rather than charts.