### PR TITLE
fix(F07): debounce file watcher to prevent excessive tree refreshes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,20 @@
 import * as vscode from "vscode";
 import { ChartProfilesProvider, ChartTreeItem } from "./core/chartProfilesProvider";
-import type { HelmChart } from "./k8s/helmChart";
-import { show as showChartVisualization, showCompare, exportComparisonReport } from "./visualization/chartVisualizationView";
-import { showValidationResults } from "./visualization/validationResultView";
-import { showRuntimeStateResults } from "./visualization/runtimeStateView";
-import { isHelmAvailable } from "./k8s/helmRenderer";
-import { showRenderedYaml } from "./utils/renderedYamlView";
-import { createChartValidator } from "./processing/chartValidator";
-import { getKubernetesConnector } from "./k8s/kubernetesConnector";
-import { getRuntimeStateManager } from "./state/runtimeStateManager";
 import { showFirstRunWalkthrough } from "./core/firstRunWalkthrough";
-
+import type { HelmChart } from "./k8s/helmChart";
+import { isHelmAvailable } from "./k8s/helmRenderer";
 import { initializeIconManager, preloadIcons } from "./k8s/iconManager";
+import { getKubernetesConnector } from "./k8s/kubernetesConnector";
+import { createChartValidator } from "./processing/chartValidator";
+import { getRuntimeStateManager } from "./state/runtimeStateManager";
+import { showRenderedYaml } from "./utils/renderedYamlView";
+import {
+	exportComparisonReport,
+	show as showChartVisualization,
+	showCompare,
+} from "./visualization/chartVisualizationView";
+import { showRuntimeStateResults } from "./visualization/runtimeStateView";
+import { showValidationResults } from "./visualization/validationResultView";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Initialize icon manager and preload icons
@@ -257,12 +260,9 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	// Register getting-started walkthrough command (can be triggered manually from the Command Palette)
-	const startWalkthroughCommand = vscode.commands.registerCommand(
-		"chartProfiles.startWalkthrough",
-		async () => {
-			await showFirstRunWalkthrough(context, /* forceShow */ true);
-		}
-	);
+	const startWalkthroughCommand = vscode.commands.registerCommand("chartProfiles.startWalkthrough", async () => {
+		await showFirstRunWalkthrough(context, /* forceShow */ true);
+	});
 
 	context.subscriptions.push(
 		treeView,
@@ -279,11 +279,27 @@ export function activate(context: vscode.ExtensionContext) {
 		startWalkthroughCommand
 	);
 
-	// Auto-refresh when workspace files change
+	// Auto-refresh when workspace files change (debounced to batch rapid saves)
+	function debounce(fn: () => void, delay: number): () => void {
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
+		return () => {
+			if (timeoutId) {
+				clearTimeout(timeoutId);
+			}
+			timeoutId = setTimeout(fn, delay);
+		};
+	}
+
+	const debouncedRefresh = debounce(() => {
+		chartProfilesProvider.refresh();
+		chartProfilesProvider.clearCache();
+		runtimeStateManager.clearCache();
+	}, 500);
+
 	const fileWatcher = vscode.workspace.createFileSystemWatcher("**/{Chart.yaml,values*.yaml}");
-	fileWatcher.onDidCreate(() => chartProfilesProvider.refresh());
-	fileWatcher.onDidChange(() => chartProfilesProvider.refresh());
-	fileWatcher.onDidDelete(() => chartProfilesProvider.refresh());
+	fileWatcher.onDidCreate(debouncedRefresh);
+	fileWatcher.onDidChange(debouncedRefresh);
+	fileWatcher.onDidDelete(debouncedRefresh);
 	context.subscriptions.push(fileWatcher);
 
 	// Auto-refresh when workspace folders change (multi-root support)


### PR DESCRIPTION
Add a 500ms debounce to the file system watcher so rapid file changes (e.g. format-on-save) batch into a single refresh. The clearCache() calls for both chartProfilesProvider and runtimeStateManager are now inside the debounced function, so caches are only cleared once per batch of changes.

Audit finding F07