### PR TITLE
fix: skip symlinks in copyDirectorySync, convert file I/O to async (F…

### DIFF
--- a/src/core/firstRunWalkthrough.ts
+++ b/src/core/firstRunWalkthrough.ts
@@ -1,20 +1,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
-import {
-	FIRST_RUN_STATE_KEY,
-	QUICK_START_URL,
-	shouldShowWalkthrough,
-} from "./walkthroughSettings";
+import { FIRST_RUN_STATE_KEY, QUICK_START_URL, shouldShowWalkthrough } from "./walkthroughSettings";
 
 /**
  * Returns true when the first-run walkthrough should be shown to the user.
  */
 export function isFirstRun(context: vscode.ExtensionContext): boolean {
 	const hasCompletedBefore = context.globalState.get<boolean>(FIRST_RUN_STATE_KEY, false);
-	const configEnabled = vscode.workspace
-		.getConfiguration("chartProfiles")
-		.get<boolean>("showWalkthroughOnFirstRun");
+	const configEnabled = vscode.workspace.getConfiguration("chartProfiles").get<boolean>("showWalkthroughOnFirstRun");
 	return shouldShowWalkthrough(hasCompletedBefore, configEnabled);
 }
 
@@ -33,10 +27,7 @@ export async function markFirstRunComplete(context: vscode.ExtensionContext): Pr
  * @param forceShow - When true, bypasses the "already seen" and "disabled" checks.
  *                    Used when the user manually triggers the walkthrough.
  */
-export async function showFirstRunWalkthrough(
-	context: vscode.ExtensionContext,
-	forceShow = false,
-): Promise<void> {
+export async function showFirstRunWalkthrough(context: vscode.ExtensionContext, forceShow = false): Promise<void> {
 	if (!forceShow && !isFirstRun(context)) {
 		return;
 	}
@@ -46,7 +37,7 @@ export async function showFirstRunWalkthrough(
 			"Would you like to explore with sample files or read the quick-start guide?",
 		"Use Sample Files",
 		"Open Quick Start",
-		"Don't Show Again",
+		"Don't Show Again"
 	);
 
 	// User dismissed the dialog without making a choice — leave the flag unset so
@@ -96,7 +87,7 @@ async function copySampleFilesToWorkspace(context: vscode.ExtensionContext): Pro
 		const result = await vscode.window.showErrorMessage(
 			"Sample files not found in this installation. " +
 				"Please visit the quick-start guide for manual setup instructions.",
-			"Open Quick Start",
+			"Open Quick Start"
 		);
 		if (result === "Open Quick Start") {
 			vscode.env.openExternal(vscode.Uri.parse(QUICK_START_URL));
@@ -113,7 +104,7 @@ async function copySampleFilesToWorkspace(context: vscode.ExtensionContext): Pro
 		const result = await vscode.window.showErrorMessage(
 			`Failed to copy sample files: ${message}. ` +
 				"Try manually copying the examples/ directory, or open the quick-start guide.",
-			"Open Quick Start",
+			"Open Quick Start"
 		);
 		if (result === "Open Quick Start") {
 			vscode.env.openExternal(vscode.Uri.parse(QUICK_START_URL));
@@ -124,7 +115,7 @@ async function copySampleFilesToWorkspace(context: vscode.ExtensionContext): Pro
 	const openChoice = await vscode.window.showInformationMessage(
 		`Sample chart copied to ${destPath}. Open it now to start comparing environments?`,
 		"Open Folder",
-		"Add to Workspace",
+		"Add to Workspace"
 	);
 
 	if (openChoice === "Open Folder") {
@@ -134,7 +125,7 @@ async function copySampleFilesToWorkspace(context: vscode.ExtensionContext): Pro
 			uri: vscode.Uri.file(destPath),
 		});
 		vscode.window.showInformationMessage(
-			`sample-app added to workspace. Expand it in the Chart Profiles panel to start exploring.`,
+			`sample-app added to workspace. Expand it in the Chart Profiles panel to start exploring.`
 		);
 	}
 }
@@ -152,6 +143,9 @@ function copyDirectorySync(src: string, dest: string): void {
 		const srcPath = path.join(src, entry.name);
 		const destPath = path.join(dest, entry.name);
 
+		if (entry.isSymbolicLink()) {
+			continue;
+		}
 		if (entry.isDirectory()) {
 			copyDirectorySync(srcPath, destPath);
 		} else {

--- a/src/k8s/helmChart.ts
+++ b/src/k8s/helmChart.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { SKIP_DIRECTORIES } from "../utils/constants";
-import { parseYaml, type ChartYaml } from "../utils/yaml";
+import { type ChartYaml, parseYaml } from "../utils/yaml";
 
 export interface HelmChart {
 	name: string;
@@ -31,7 +31,7 @@ export async function findHelmCharts(workspaceRoots: string[]): Promise<HelmChar
 
 async function findChartsRecursive(dirPath: string, charts: HelmChart[]): Promise<void> {
 	try {
-		const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+		const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
 
 		for (const entry of entries) {
 			const fullPath = path.join(dirPath, entry.name);
@@ -40,7 +40,15 @@ async function findChartsRecursive(dirPath: string, charts: HelmChart[]): Promis
 			if (entry.isDirectory() && !shouldSkipDirectory(entry.name)) {
 				// Check if this directory contains a Chart.yaml
 				const chartYamlPath = path.join(fullPath, "Chart.yaml");
-				if (fs.existsSync(chartYamlPath)) {
+				let chartYamlExists = false;
+				try {
+					await fs.promises.access(chartYamlPath);
+					chartYamlExists = true;
+				} catch {
+					// Chart.yaml does not exist
+				}
+
+				if (chartYamlExists) {
 					const chart = await parseChartYaml(chartYamlPath, fullPath);
 					if (chart) {
 						charts.push(chart);
@@ -61,7 +69,7 @@ async function findChartsRecursive(dirPath: string, charts: HelmChart[]): Promis
 
 async function parseChartYaml(chartYamlPath: string, chartPath: string): Promise<HelmChart | null> {
 	try {
-		const content = fs.readFileSync(chartYamlPath, "utf8");
+		const content = await fs.promises.readFile(chartYamlPath, "utf8");
 		const chartData = parseYaml<ChartYaml>(content);
 
 		if (!chartData) {

--- a/src/k8s/helmRenderer.ts
+++ b/src/k8s/helmRenderer.ts
@@ -2,8 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
 import { mergeValues } from "../processing/valuesMerger";
-import { BUFFER_SIZE, TIMEOUT } from "../utils/constants";
 import { runHelm } from "../utils/cliRunner";
+import { BUFFER_SIZE, TIMEOUT } from "../utils/constants";
 
 // Template variable patterns for substitution
 const TEMPLATE_PATTERNS = {
@@ -41,7 +41,7 @@ export async function renderHelmTemplate(
 
 	if (!helmAvailable) {
 		console.warn("Helm CLI not found. Using placeholder rendering.");
-		return getPlaceholderResources(chartPath, environment);
+		return await getPlaceholderResources(chartPath, environment);
 	}
 
 	// Keep a printable command preview for diagnostics
@@ -243,13 +243,15 @@ export async function isHelmAvailable(): Promise<boolean> {
 /**
  * Returns fallback resources when Helm is not available by reading and partially rendering template files
  */
-function getPlaceholderResources(chartPath: string, environment: string): RenderedResource[] {
+async function getPlaceholderResources(chartPath: string, environment: string): Promise<RenderedResource[]> {
 	const chartName = path.basename(chartPath);
 	const templatesDir = path.join(chartPath, "templates");
 	const resources: RenderedResource[] = [];
 
 	// Check if templates directory exists
-	if (!fs.existsSync(templatesDir)) {
+	try {
+		await fs.promises.access(templatesDir);
+	} catch {
 		return [
 			{
 				kind: "Notice",
@@ -271,25 +273,31 @@ function getPlaceholderResources(chartPath: string, environment: string): Render
 		let chartVersion = DEFAULT_CHART_VERSION;
 		try {
 			const chartYamlPath = path.join(chartPath, "Chart.yaml");
-			if (fs.existsSync(chartYamlPath)) {
-				const chartYaml = yaml.load(fs.readFileSync(chartYamlPath, "utf8")) as any;
+			try {
+				await fs.promises.access(chartYamlPath);
+				const chartYamlContent = await fs.promises.readFile(chartYamlPath, "utf8");
+				const chartYaml = yaml.load(chartYamlContent) as any;
 				if (chartYaml && chartYaml.version) {
 					chartVersion = chartYaml.version;
 				}
+			} catch {
+				// Chart.yaml does not exist, skip
 			}
 		} catch (error) {
 			console.warn("Could not read Chart.yaml version:", error);
 		}
 
 		// Read all template files
-		const templateFiles = fs
-			.readdirSync(templatesDir)
-			.filter((file: string) => file.endsWith(".yaml") || file.endsWith(".yml"))
-			.filter((file: string) => !file.startsWith("_")); // Skip helper files
+		const dirEntries = await fs.promises.readdir(templatesDir, { withFileTypes: true });
+		const templateFiles = dirEntries
+			.filter((entry: fs.Dirent) => entry.isFile())
+			.map((entry: fs.Dirent) => entry.name)
+			.filter((name: string) => name.endsWith(".yaml") || name.endsWith(".yml"))
+			.filter((name: string) => !name.startsWith("_")); // Skip helper files
 
 		for (const templateFile of templateFiles) {
 			const templatePath = path.join(templatesDir, templateFile);
-			let templateContent = fs.readFileSync(templatePath, "utf8");
+			let templateContent = await fs.promises.readFile(templatePath, "utf8");
 
 			// Perform basic Go template variable substitution
 			const releaseName = `${chartName}-${environment}`;


### PR DESCRIPTION
…06, F08, F14)

- F06: copyDirectorySync now skips symbolic links to prevent infinite recursion
- F08: getPlaceholderResources now uses async fs.promises for all file I/O
- F14: findChartsRecursive and parseChartYaml now use async fs.promises instead of sync counterparts (readdirSync, existsSync, readFileSync)