### PR TITLE
Implemented chart-specific render context via .chart-profile.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,153 +1,53 @@
 # Helm Chart Visualizer
 
-Visualize, validate, compare, and monitor Helm chart environments directly inside VS Code.
+VS Code extension for visualizing, validating, comparing, and monitoring Helm charts.
 
-This extension is designed for teams managing multiple environment overlays (`values-dev.yaml`, `values-qa.yaml`, `values-prod.yaml`, etc.) and wanting a fast, consistent desktop workflow for release confidence.
+## Features
 
-![Build & Release VS Code Extension](https://github.com/chaluvadis/chart-profile-visualizer/actions/workflows/workflow.yml/badge.svg)
+- **Visualize Chart** - View resource architecture, values, and rendered YAML
+- **Validate Chart** - Check for errors, warnings, and best practices
+- **Compare Environments** - Side-by-side comparison between dev/staging/prod
+- **Check Runtime State** - View cluster status against rendered resources
+- **Export** - YAML, JSON, and Markdown reports
 
-## What You Can Do
+## Quick Start
 
-- Visualize a chart environment with architecture and resource insights
-- Validate chart quality and best-practice issues in an actionable UI
-- Compare two environments with field-level change details
-- Export comparison results as Markdown (for humans) or JSON (for automation)
-- Check runtime state against the cluster in a dedicated runtime dashboard
-- Export rendered manifests as YAML or JSON
+1. Open a workspace with Helm charts (folders containing `Chart.yaml`)
+2. Open the **Chart Profiles** view in VS Code Explorer
+3. Expand a chart and click an environment
+4. Select **Visualize Chart**, **Validate Chart**, or **Compare Environments**
 
-## Tree View Experience
+## Chart-Specific Configuration
 
-In Explorer, open **Chart Profiles** and expand:
+Add `.chart-profile.yaml` in your chart directory to configure release name and namespace per environment:
 
-- `Chart`
-  - `Compare Environments`
-  - `Environment (dev/qa/staging/prod...)`
-    - `Visualize Chart`
-    - `Validate Chart`
-    - `Check Runtime State`
+```yaml
+# Default values
+releaseName: my-app
+namespace: my-app
 
-The tree is environment-aware and supports multi-root workspaces.
-
-## Core Workflows
-
-## 1) Visualize Chart
-
-`Visualize Chart` opens a desktop-first webview with:
-
-- **Overview tab**
-  - Resource architecture graph/topology
-  - Values and override summary cards
-  - Chart-level metrics
-- **Resources tab**
-  - Grouped resources by Kubernetes kind
-  - Expandable resource cards with YAML
-  - Copy resource YAML action
-- **Toolbar actions**
-  - Export YAML
-  - Export JSON
-
-## 2) Validate Chart
-
-`Validate Chart` opens a dedicated validation view with:
-
-- Status header aligned to result severity
-- Error/Warning/Info summaries
-- Search and severity filtering
-- Cards view and table view
-- Grouping, sorting, and actionable filtering
-- Quick actions:
-  - Copy issue text
-  - Jump to file/line when location is available
-
-## 3) Compare Environments
-
-`Compare Environments` provides:
-
-- Side-by-side environment comparison
-- Added/Removed/Modified resource categorization
-- Field-level value differences
-- Change filters and grouped summaries
-- **Export Comparison Report** — export as Markdown or JSON
-
-### Export Comparison Report
-
-After running a comparison, click **📤 Export Report** in the comparison view header, or run **Export Comparison Report** from the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
-
-You will be prompted to choose a save location and file format:
-
-- **Markdown (`.md`)** — Human-readable report for PR reviews and change approvals
-- **JSON (`.json`)** — Machine-readable output for automation pipelines
-
-#### Example Markdown Output
-
-```markdown
-# Comparison Report: dev vs prod
-**Chart:** sample-app
-**Generated:** 2026-03-25T16:00:00.000Z
-
-## Summary
-
-### Change Counts
-| Category  | Count |
-|-----------|-------|
-| Added     | 1     |
-| Removed   | 0     |
-| Modified  | 2     |
-| Unchanged | 5     |
-| **Total** | **8** |
-| Change %  | 37.5% |
-
-### Severity Counts
-| Severity    | Count |
-|-------------|-------|
-| 🔴 Critical | 1     |
-| 🟡 Warning  | 3     |
-| 🔵 Info     | 2     |
-
-## Drift List
-
-### Deployment/sample-app
-**Status:** modified — **Critical**
-
-| Field | dev | prod | Severity |
-|-------|-----|------|----------|
-| `spec.replicas` | `1` | `3` | critical |
-| `spec.template.spec.containers[0].resources.limits.memory` | `"256Mi"` | `"512Mi"` | warning |
+# Environment overrides
+environments:
+  dev:
+    releaseName: my-app-dev
+    namespace: dev
+  prod:
+    releaseName: my-app
+    namespace: production
 ```
 
-#### Example JSON Output
-
-The JSON export contains the full structured comparison data, including header, summary, resource list, field diffs, and kind groups — suitable for CI/CD pipelines and automated drift analysis.
-
-## 4) Check Runtime State
-
-`Check Runtime State` opens a runtime dashboard (not raw markdown):
-
-- Cluster context and connection state
-- Healthy/Warning/Critical/NotFound/Unknown summaries
-- Structured resource status sections
-- All resources list with quick actions:
-  - **View YAML**
-- Helm release summary table
+**Precedence order** (highest to lowest):
+1. Workspace settings
+2. Environment-specific profile
+3. Chart-level profile
+4. Built-in defaults
 
 ## Requirements
 
 - VS Code `^1.110.0`
-- Helm CLI (`helm`) for rendering/validation flows
-- Kubernetes CLI (`kubectl`) for runtime state flows
+- Helm CLI (`helm`) - for rendering/validation
+- kubectl - for runtime state
 
-## Example Chart Layout
-
-```text
-sample-app/
-  Chart.yaml
-  values.yaml
-  values-dev.yaml
-  values-qa.yaml
-  values-staging.yaml
-  values-prod.yaml
-  templates/
-```
 ## Development
 
 ```bash
@@ -155,34 +55,6 @@ pnpm install
 pnpm run compile
 ```
 
-Useful scripts:
-
-- `pnpm run compile` - build extension + webview assets
-- `pnpm run lint` - lint with Biome
-- `pnpm run format` - format with Biome
-- `pnpm run package` - compile and produce `.vsix`
-
-## Security and Privacy Notes
-
-- Local-first processing: chart rendering and analysis happen on your machine
-- Runtime queries are executed through local CLIs (`kubectl`, `helm`)
-- HTML output uses escaping and constrained templating paths
-- Sensitive manifest content handling includes redaction safeguards in resource flows
-
-## Architecture
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for module-level design and data flow.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
 ## License
 
 MIT
-
-## Support
-
-Issues and feature requests:
-
-- https://github.com/chaluvadis/chart-profile-visualizer/issues

--- a/examples/sample-app/.chart-profile.yaml
+++ b/examples/sample-app/.chart-profile.yaml
@@ -1,0 +1,21 @@
+# Chart Profile Configuration
+# This file defines chart-specific rendering context settings
+
+# Default release name and namespace for this chart
+releaseName: sample-app
+namespace: sample-app
+
+# Environment-specific overrides
+environments:
+  dev:
+    releaseName: sample-app-dev
+    namespace: dev
+  staging:
+    releaseName: sample-app-staging
+    namespace: staging
+  uat:
+    releaseName: sample-app-uat
+    namespace: uat
+  prod:
+    releaseName: sample-app
+    namespace: production

--- a/examples/sample-app/rendered-resources.yaml
+++ b/examples/sample-app/rendered-resources.yaml
@@ -1,0 +1,69 @@
+# Source: sample-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-app-service
+  labels:
+    app: sample-app
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: sample-app
+---
+# Source: sample-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-app-deployment
+  labels:
+    app: sample-app
+    environment: dev
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sample-app
+  template:
+    metadata:
+      labels:
+        app: sample-app
+        environment: dev
+    spec:
+      containers:
+      - name: sample-app
+        image: "nginx:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+---
+# Source: sample-app/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sample-app-ingress
+  labels:
+    app: sample-app
+spec:
+  rules:
+  - host: "dev.example.com"
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: sample-app-service
+            port:
+              number: 80

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart-profile-visualizer",
   "displayName": "Helm Chart Visualizer",
   "description": "Visualize Helm charts across environments with value merging and template rendering",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "nomad-in-code",
   "repository": {
     "type": "git",
@@ -137,7 +137,6 @@
           "when": "false"
         },
         {
-          
           "command": "chartProfiles.validateChart",
           "when": "false"
         },
@@ -177,7 +176,7 @@
         },
         "chartProfiles.renderContext.releaseName": {
           "type": "string",
-          "default": "RELEASE-NAME",
+          "default": "chart-profile",
           "description": "Helm release name used when rendering templates, visualizing, validating, or comparing charts. Corresponds to `.Release.Name` in Helm templates."
         },
         "chartProfiles.renderContext.namespace": {
@@ -200,13 +199,13 @@
     "test": "tsc -p tsconfig.test.json && node test/driftSeverity.test.js && node test/kubectlDetection.test.js && node test/firstRunWalkthrough.test.js && node test/renderContext.test.js"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.11",
+    "@biomejs/biome": "^2.4.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.6.2",
     "@types/vscode": "^1.110.0",
-    "@vscode/vsce": "^3.7.1",
+    "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.28.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "chart.js": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,13 @@
         "title": "Start Walkthrough",
         "description": "Start the chart profiles walkthrough",
         "category": "Chart Profiles"
+      },
+      {
+        "command": "chartProfiles.configureRenderContext",
+        "title": "Configure Render Context",
+        "description": "Set the release name and namespace used when rendering Helm templates",
+        "category": "Chart Profiles",
+        "icon": "$(gear)"
       }
     ],
     "menus": {
@@ -115,6 +122,11 @@
         },
         {
           "command": "chartProfiles.updateDependencies",
+          "when": "view == chartProfiles",
+          "group": "navigation"
+        },
+        {
+          "command": "chartProfiles.configureRenderContext",
           "when": "view == chartProfiles",
           "group": "navigation"
         }
@@ -162,6 +174,16 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to show the guided walkthrough automatically on the first activation."
+        },
+        "chartProfiles.renderContext.releaseName": {
+          "type": "string",
+          "default": "RELEASE-NAME",
+          "description": "Helm release name used when rendering templates, visualizing, validating, or comparing charts. Corresponds to `.Release.Name` in Helm templates."
+        },
+        "chartProfiles.renderContext.namespace": {
+          "type": "string",
+          "default": "default",
+          "description": "Kubernetes namespace passed to `helm template --namespace` during rendering, visualization, validation, and comparison."
         }
       }
     }
@@ -175,7 +197,7 @@
     "lint:fix": "biome lint --write .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
-    "test": "tsc -p tsconfig.test.json && node test/driftSeverity.test.js && node test/kubectlDetection.test.js && node test/firstRunWalkthrough.test.js"
+    "test": "tsc -p tsconfig.test.json && node test/driftSeverity.test.js && node test/kubectlDetection.test.js && node test/firstRunWalkthrough.test.js && node test/renderContext.test.js"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,26 +16,26 @@ importers:
         version: 4.1.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.11
-        version: 2.4.11
+        specifier: ^2.4.14
+        version: 2.4.14
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
+        specifier: ^25.6.2
+        version: 25.6.2
       '@types/vscode':
         specifier: ^1.110.0
-        version: 1.110.0
+        version: 1.118.0
       '@vscode/vsce':
-        specifier: ^3.7.1
-        version: 3.7.1
+        specifier: ^3.9.1
+        version: 3.9.1
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -57,8 +57,8 @@ packages:
     resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/core-rest-pipeline@1.22.2':
-    resolution: {integrity: sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==}
+  '@azure/core-rest-pipeline@1.23.0':
+    resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
     engines: {node: '>=20.0.0'}
 
   '@azure/core-tracing@1.3.1':
@@ -69,25 +69,25 @@ packages:
     resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/identity@4.13.0':
-    resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
     engines: {node: '>=20.0.0'}
 
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/msal-browser@4.28.2':
-    resolution: {integrity: sha512-6vYUMvs6kJxJgxaCmHn/F8VxjLHNh7i9wzfwPGf8kyBJ8Gg2yvBXx175Uev8LdrD1F5C4o7qHa2CC4IrhGE1XQ==}
+  '@azure/msal-browser@5.10.0':
+    resolution: {integrity: sha512-2Y4TlG5mCfxviHutfW50i8Xd8xhGKTgieL02vMYOE5ZbZrVM+drKSGD//tweRAmlmqqp+F9vrKoHWri/buzxWQ==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.14.2':
-    resolution: {integrity: sha512-n8RBJEUmd5QotoqbZfd+eGBkzuFI1KX6jw2b3WcpSyGjwmzoeI/Jb99opIBPHpb8y312NB+B6+FGi2ZVSR8yfA==}
+  '@azure/msal-common@16.6.0':
+    resolution: {integrity: sha512-FemGljX0csPlBMUE5GUan7BfRn1emeMRUhHSARhqzLN6LA9nt+MgzmAQ1xVqdLm+6plVoxsq9mS5eoyKtpPSgA==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@3.8.7':
-    resolution: {integrity: sha512-a+Xnrae+uwLnlw68bplS1X4kuJ9F/7K6afuMFyRkNIskhjgDezl5Fhrx+1pmAlDmC0VaaAxjRQMp1OmcqVwkIg==}
-    engines: {node: '>=16'}
+  '@azure/msal-node@5.2.0':
+    resolution: {integrity: sha512-b/ak8XAqpnGk1N1nsyTVV0Remp48BP3QrGQZ1uCMcvg2S8X1eSXzhHQZEae2oX276Q4KFAqCUswanDtcvIKLrw==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -97,59 +97,59 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.11':
-    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
+  '@biomejs/biome@2.4.14':
+    resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
-    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
+  '@biomejs/cli-darwin-arm64@2.4.14':
+    resolution: {integrity: sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.11':
-    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
+  '@biomejs/cli-darwin-x64@2.4.14':
+    resolution: {integrity: sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
-    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
+  '@biomejs/cli-linux-arm64-musl@2.4.14':
+    resolution: {integrity: sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.11':
-    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
+  '@biomejs/cli-linux-arm64@2.4.14':
+    resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
-    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
+  '@biomejs/cli-linux-x64-musl@2.4.14':
+    resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.11':
-    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
+  '@biomejs/cli-linux-x64@2.4.14':
+    resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.11':
-    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
+  '@biomejs/cli-win32-arm64@2.4.14':
+    resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.11':
-    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
+  '@biomejs/cli-win32-x64@2.4.14':
+    resolution: {integrity: sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -310,14 +310,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -386,26 +378,26 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@textlint/ast-node-types@15.5.1':
-    resolution: {integrity: sha512-2ABQSaQoM9u9fycXLJKcCv4XQulJWTUSwjo6F0i/ujjqOH8/AZ2A0RDKKbAddqxDhuabVB20lYoEsZZgzehccg==}
+  '@textlint/ast-node-types@15.6.0':
+    resolution: {integrity: sha512-CxZHFbYAU7J0A4izz31wV2ZZfySR6aVj2OSR6/3tppZm7VV6hM7nA7sutsLwIiBL/v4lsB1RM79l4Dc/VrH4qw==}
 
-  '@textlint/linter-formatter@15.5.1':
-    resolution: {integrity: sha512-7wfzpcQtk7TZ3UJO2deTI71mJCm4VvPGUmSwE4iuH6FoaxpdWpwSBiMLcZtjYrt/oIFOtNz0uf5rI+xJiHTFww==}
+  '@textlint/linter-formatter@15.6.0':
+    resolution: {integrity: sha512-IwHRhjwxs0a5t1eNAoKAdV224CDca38LyopPofXpwO/d0J75wBvzf/cBHXNl4TMsLKhYGtR83UprcLEKj/gZsA==}
 
-  '@textlint/module-interop@15.5.1':
-    resolution: {integrity: sha512-Y1jcFGCKNSmHxwsLO3mshOfLYX4Wavq2+w5BG6x5lGgZv0XrF1xxURRhbnhns4LzCu0fAcx6W+3V8/1bkyTZCw==}
+  '@textlint/module-interop@15.6.0':
+    resolution: {integrity: sha512-MHY6pJx9i5kOlrvUSK51887tYZjHAV2qnr6unBm7LtBLGDFo93utdYqHyWep8r9QLsilQdeijWtufJI46z4v4w==}
 
-  '@textlint/resolver@15.5.1':
-    resolution: {integrity: sha512-CVHxMIm8iNGccqM12CQ/ycvh+HjJId4RyC6as5ynCcp2E1Uy1TCe0jBWOpmLsbT4Nx15Ke29BmspyByawuIRyA==}
+  '@textlint/resolver@15.6.0':
+    resolution: {integrity: sha512-T1l2Gd3455pwtm0cTewhX/LLy3bL9z6/Fu/am+jj+jjGfXVoknYkjfkZEKrjHlA7xzay0EfUKnu//teYemLeZw==}
 
-  '@textlint/types@15.5.1':
-    resolution: {integrity: sha512-IY1OVZZk8LOOrbapYCsaeH7XSJT89HVukixDT8CoiWMrKGCTCZ3/Kzoa3DtMMbY8jtY777QmPOVCNnR+8fF6YQ==}
+  '@textlint/types@15.6.0':
+    resolution: {integrity: sha512-CvgYb1PiqF4BGyoZebGWzAJCZ4ChJAZ9gtWjpQIMKE4Xe2KlSwDA8m8MsiZIV321f5Ibx38BMjC1Z/2ZYP2GQg==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -413,11 +405,11 @@ packages:
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
-  '@types/vscode@1.110.0':
-    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+  '@types/vscode@1.118.0':
+    resolution: {integrity: sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==}
 
-  '@typespec/ts-http-runtime@0.3.3':
-    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+  '@typespec/ts-http-runtime@0.3.5':
+    resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
@@ -468,8 +460,8 @@ packages:
   '@vscode/vsce-sign@2.0.9':
     resolution: {integrity: sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==}
 
-  '@vscode/vsce@3.7.1':
-    resolution: {integrity: sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==}
+  '@vscode/vsce@3.9.1':
+    resolution: {integrity: sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -477,8 +469,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -512,6 +504,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -528,8 +524,12 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -729,14 +729,11 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -753,8 +750,8 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.3:
-    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   function-bind@1.1.2:
@@ -804,8 +801,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hosted-git-info@4.1.0:
@@ -874,8 +871,8 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   isexe@2.0.0:
@@ -907,8 +904,8 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -954,14 +951,14 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.6:
-    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
@@ -1004,18 +1001,18 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.1.2:
-    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
@@ -1030,8 +1027,8 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
-  node-abi@3.87.0:
-    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
   node-addon-api@4.3.0:
@@ -1086,9 +1083,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
@@ -1100,8 +1097,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   pluralize@2.0.0:
@@ -1114,24 +1111,25 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  rc-config-loader@4.1.3:
-    resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
+  rc-config-loader@4.1.4:
+    resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1170,8 +1168,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.4.4:
-    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
   secretlint@10.2.2:
@@ -1196,8 +1194,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -1239,8 +1237,8 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
-  spdx-license-ids@3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1253,8 +1251,8 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
@@ -1319,22 +1317,22 @@ packages:
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.21.0:
-    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -1354,10 +1352,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -1398,8 +1392,9 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
 
   yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
@@ -1428,7 +1423,7 @@ snapshots:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-rest-pipeline': 1.23.0
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
@@ -1436,14 +1431,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-rest-pipeline@1.22.2':
+  '@azure/core-rest-pipeline@1.23.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.10.1
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -1455,22 +1450,22 @@ snapshots:
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.13.0':
+  '@azure/identity@4.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.10.1
       '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-rest-pipeline': 1.23.0
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
-      '@azure/msal-browser': 4.28.2
-      '@azure/msal-node': 3.8.7
+      '@azure/msal-browser': 5.10.0
+      '@azure/msal-node': 5.2.0
       open: 10.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -1478,22 +1473,21 @@ snapshots:
 
   '@azure/logger@1.3.0':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/msal-browser@4.28.2':
+  '@azure/msal-browser@5.10.0':
     dependencies:
-      '@azure/msal-common': 15.14.2
+      '@azure/msal-common': 16.6.0
 
-  '@azure/msal-common@15.14.2': {}
+  '@azure/msal-common@16.6.0': {}
 
-  '@azure/msal-node@3.8.7':
+  '@azure/msal-node@5.2.0':
     dependencies:
-      '@azure/msal-common': 15.14.2
+      '@azure/msal-common': 16.6.0
       jsonwebtoken: 9.0.3
-      uuid: 8.3.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1503,39 +1497,39 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@biomejs/biome@2.4.11':
+  '@biomejs/biome@2.4.14':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.11
-      '@biomejs/cli-darwin-x64': 2.4.11
-      '@biomejs/cli-linux-arm64': 2.4.11
-      '@biomejs/cli-linux-arm64-musl': 2.4.11
-      '@biomejs/cli-linux-x64': 2.4.11
-      '@biomejs/cli-linux-x64-musl': 2.4.11
-      '@biomejs/cli-win32-arm64': 2.4.11
-      '@biomejs/cli-win32-x64': 2.4.11
+      '@biomejs/cli-darwin-arm64': 2.4.14
+      '@biomejs/cli-darwin-x64': 2.4.14
+      '@biomejs/cli-linux-arm64': 2.4.14
+      '@biomejs/cli-linux-arm64-musl': 2.4.14
+      '@biomejs/cli-linux-x64': 2.4.14
+      '@biomejs/cli-linux-x64-musl': 2.4.14
+      '@biomejs/cli-win32-arm64': 2.4.14
+      '@biomejs/cli-win32-x64': 2.4.14
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
+  '@biomejs/cli-darwin-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.11':
+  '@biomejs/cli-darwin-x64@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
+  '@biomejs/cli-linux-arm64-musl@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.11':
+  '@biomejs/cli-linux-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
+  '@biomejs/cli-linux-x64-musl@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.11':
+  '@biomejs/cli-linux-x64@2.4.14':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.11':
+  '@biomejs/cli-win32-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.11':
+  '@biomejs/cli-win32-x64@2.4.14':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
@@ -1616,12 +1610,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/cliui@9.0.0': {}
 
   '@kurkle/color@0.3.4': {}
@@ -1647,9 +1635,9 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
-      ajv: 8.17.1
+      ajv: 8.20.0
       debug: 4.4.3
-      rc-config-loader: 4.1.3
+      rc-config-loader: 4.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -1666,13 +1654,13 @@ snapshots:
     dependencies:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
-      '@textlint/linter-formatter': 15.5.1
-      '@textlint/module-interop': 15.5.1
-      '@textlint/types': 15.5.1
+      '@textlint/linter-formatter': 15.6.0
+      '@textlint/module-interop': 15.6.0
+      '@textlint/types': 15.6.0
       chalk: 5.6.2
       debug: 4.4.3
       pluralize: 8.0.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
       table: 6.9.0
       terminal-link: 4.0.0
     transitivePeerDependencies:
@@ -1714,19 +1702,19 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@textlint/ast-node-types@15.5.1': {}
+  '@textlint/ast-node-types@15.6.0': {}
 
-  '@textlint/linter-formatter@15.5.1':
+  '@textlint/linter-formatter@15.6.0':
     dependencies:
       '@azu/format-text': 1.0.2
       '@azu/style-format': 1.0.1
-      '@textlint/module-interop': 15.5.1
-      '@textlint/resolver': 15.5.1
-      '@textlint/types': 15.5.1
+      '@textlint/module-interop': 15.6.0
+      '@textlint/resolver': 15.6.0
+      '@textlint/types': 15.6.0
       chalk: 4.1.2
       debug: 4.4.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -1735,17 +1723,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@textlint/module-interop@15.5.1': {}
+  '@textlint/module-interop@15.6.0': {}
 
-  '@textlint/resolver@15.5.1': {}
+  '@textlint/resolver@15.6.0': {}
 
-  '@textlint/types@15.5.1':
+  '@textlint/types@15.6.0':
     dependencies:
-      '@textlint/ast-node-types': 15.5.1
+      '@textlint/ast-node-types': 15.6.0
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
 
@@ -1753,9 +1741,9 @@ snapshots:
 
   '@types/sarif@2.1.7': {}
 
-  '@types/vscode@1.110.0': {}
+  '@types/vscode@1.118.0': {}
 
-  '@typespec/ts-http-runtime@0.3.3':
+  '@typespec/ts-http-runtime@0.3.5':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -1802,9 +1790,9 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.7.1':
+  '@vscode/vsce@3.9.1':
     dependencies:
-      '@azure/identity': 4.13.0
+      '@azure/identity': 4.13.1
       '@secretlint/node': 10.2.2
       '@secretlint/secretlint-formatter-sarif': 10.2.2
       '@secretlint/secretlint-rule-no-dotenv': 10.2.2
@@ -1822,7 +1810,7 @@ snapshots:
       leven: 3.1.0
       markdown-it: 14.1.1
       mime: 1.6.0
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       parse-semver: 1.1.1
       read: 1.0.7
       secretlint: 10.2.2
@@ -1831,7 +1819,7 @@ snapshots:
       typed-rest-client: 1.8.11
       url-join: 4.0.1
       xml2js: 0.5.0
-      yauzl: 2.10.0
+      yauzl: 3.3.0
       yazl: 2.5.1
     optionalDependencies:
       keytar: 7.9.0
@@ -1840,10 +1828,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1872,6 +1860,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1:
     optional: true
 
@@ -1890,10 +1880,14 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -1954,7 +1948,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.21.0
+      undici: 7.25.0
       whatwg-mimetype: 4.0.0
 
   chownr@1.1.4:
@@ -2083,7 +2077,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -2127,15 +2121,11 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fill-range@7.1.1:
     dependencies:
@@ -2151,16 +2141,16 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   fs-constants@1.0.0:
     optional: true
 
-  fs-extra@11.3.3:
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   function-bind@1.1.2: {}
@@ -2175,7 +2165,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -2194,10 +2184,10 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.1.2
-      minipass: 7.1.2
+      minimatch: 10.2.5
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.1
+      path-scurry: 2.0.2
 
   globby@14.1.0:
     dependencies:
@@ -2220,7 +2210,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -2286,7 +2276,7 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
@@ -2314,7 +2304,7 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -2372,11 +2362,11 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.6: {}
+  lru-cache@11.3.6: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -2400,7 +2390,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -2413,18 +2403,18 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  minimatch@10.1.2:
+  minimatch@10.2.5:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.1
+      brace-expansion: 5.0.6
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimist@1.2.8:
     optional: true
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -2436,7 +2426,7 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
-  node-abi@3.87.0:
+  node-abi@3.92.0:
     dependencies:
       semver: 7.7.4
     optional: true
@@ -2447,7 +2437,7 @@ snapshots:
   node-sarif-builder@3.4.0:
     dependencies:
       '@types/sarif': 2.1.7
-      fs-extra: 11.3.3
+      fs-extra: 11.3.5
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -2502,10 +2492,10 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-scurry@2.0.1:
+  path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.6
-      minipass: 7.1.2
+      lru-cache: 11.3.6
+      minipass: 7.1.3
 
   path-type@6.0.0: {}
 
@@ -2513,7 +2503,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   pluralize@2.0.0: {}
 
@@ -2527,15 +2517,15 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.87.0
-      pump: 3.0.3
+      node-abi: 3.92.0
+      pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
     optional: true
 
-  pump@3.0.3:
+  pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -2543,13 +2533,13 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
 
-  rc-config-loader@4.1.3:
+  rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
       js-yaml: 4.1.1
@@ -2599,7 +2589,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.4: {}
+  sax@1.6.0: {}
 
   secretlint@10.2.2:
     dependencies:
@@ -2623,7 +2613,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -2647,7 +2637,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -2674,16 +2664,16 @@ snapshots:
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
   spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
-  spdx-license-ids@3.0.22: {}
+  spdx-license-ids@3.0.23: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2700,7 +2690,7 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.2:
+  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -2722,7 +2712,7 @@ snapshots:
 
   table@6.9.0:
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -2732,7 +2722,7 @@ snapshots:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
-      pump: 3.0.3
+      pump: 3.0.4
       tar-stream: 2.2.0
     optional: true
 
@@ -2775,19 +2765,19 @@ snapshots:
 
   typed-rest-client@1.8.11:
     dependencies:
-      qs: 6.14.1
+      qs: 6.15.1
       tunnel: 0.0.6
-      underscore: 1.13.7
+      underscore: 1.13.8
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   undici-types@7.19.2: {}
 
-  undici@7.21.0: {}
+  undici@7.25.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -2799,8 +2789,6 @@ snapshots:
 
   util-deprecate@1.0.2:
     optional: true
-
-  uuid@8.3.2: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -2824,21 +2812,21 @@ snapshots:
 
   wsl-utils@0.1.0:
     dependencies:
-      is-wsl: 3.1.0
+      is-wsl: 3.1.1
 
   xml2js@0.5.0:
     dependencies:
-      sax: 1.4.4
+      sax: 1.6.0
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
 
   yallist@4.0.0: {}
 
-  yauzl@2.10.0:
+  yauzl@3.3.0:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yazl@2.5.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@vscode/vsce-sign': false
+  esbuild: false
+  keytar: false

--- a/src/core/renderContext.ts
+++ b/src/core/renderContext.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode";
+import {
+	buildRenderContext,
+	DEFAULT_NAMESPACE,
+	DEFAULT_RELEASE_NAME,
+	RENDER_CONTEXT_NAMESPACE_SETTING,
+	RENDER_CONTEXT_RELEASE_NAME_SETTING,
+	type RenderContext,
+} from "./renderContextSettings";
+
+// Re-export everything from the pure settings module for convenience
+export {
+	buildRenderContext,
+	DEFAULT_NAMESPACE,
+	DEFAULT_RELEASE_NAME,
+	RENDER_CONTEXT_NAMESPACE_SETTING,
+	RENDER_CONTEXT_RELEASE_NAME_SETTING,
+	type RenderContext,
+};
+
+/**
+ * Read the current render context from workspace settings.
+ * Falls back to defaults when settings are not configured.
+ */
+export function getRenderContext(): RenderContext {
+	const config = vscode.workspace.getConfiguration("chartProfiles");
+	const releaseName = config.get<string>("renderContext.releaseName");
+	const namespace = config.get<string>("renderContext.namespace");
+	return buildRenderContext(releaseName, namespace);
+}
+
+/**
+ * Prompt the user to configure the render context via Quick Input.
+ * Persists the chosen values to workspace settings and returns the result.
+ */
+export async function promptRenderContext(): Promise<RenderContext | undefined> {
+	const current = getRenderContext();
+
+	const releaseName = await vscode.window.showInputBox({
+		title: "Render Context: Release Name",
+		prompt: "Enter the Helm release name used during template rendering",
+		value: current.releaseName,
+		placeHolder: DEFAULT_RELEASE_NAME,
+		ignoreFocusOut: true,
+		validateInput: (v) => (v.trim() === "" ? "Release name cannot be empty" : undefined),
+	});
+
+	if (releaseName === undefined) {
+		// User cancelled
+		return undefined;
+	}
+
+	const namespace = await vscode.window.showInputBox({
+		title: "Render Context: Namespace",
+		prompt: "Enter the Kubernetes namespace used during template rendering",
+		value: current.namespace,
+		placeHolder: DEFAULT_NAMESPACE,
+		ignoreFocusOut: true,
+		validateInput: (v) => (v.trim() === "" ? "Namespace cannot be empty" : undefined),
+	});
+
+	if (namespace === undefined) {
+		// User cancelled
+		return undefined;
+	}
+
+	const context = buildRenderContext(releaseName, namespace);
+
+	// Persist to workspace settings
+	const config = vscode.workspace.getConfiguration("chartProfiles");
+	await config.update(
+		RENDER_CONTEXT_RELEASE_NAME_SETTING.replace("chartProfiles.", ""),
+		context.releaseName,
+		vscode.ConfigurationTarget.Workspace
+	);
+	await config.update(
+		RENDER_CONTEXT_NAMESPACE_SETTING.replace("chartProfiles.", ""),
+		context.namespace,
+		vscode.ConfigurationTarget.Workspace
+	);
+
+	return context;
+}

--- a/src/core/renderContext.ts
+++ b/src/core/renderContext.ts
@@ -5,6 +5,10 @@ import {
 	DEFAULT_RELEASE_NAME,
 	RENDER_CONTEXT_NAMESPACE_SETTING,
 	RENDER_CONTEXT_RELEASE_NAME_SETTING,
+	getChartRenderContext,
+	loadChartProfile,
+	CHART_PROFILE_FILE,
+	type ChartProfileConfig,
 	type RenderContext,
 } from "./renderContextSettings";
 
@@ -15,7 +19,11 @@ export {
 	DEFAULT_RELEASE_NAME,
 	RENDER_CONTEXT_NAMESPACE_SETTING,
 	RENDER_CONTEXT_RELEASE_NAME_SETTING,
+	loadChartProfile,
+	CHART_PROFILE_FILE,
+	type ChartProfileConfig,
 	type RenderContext,
+	getChartRenderContext,
 };
 
 /**
@@ -27,6 +35,16 @@ export function getRenderContext(): RenderContext {
 	const releaseName = config.get<string>("renderContext.releaseName");
 	const namespace = config.get<string>("renderContext.namespace");
 	return buildRenderContext(releaseName, namespace);
+}
+
+/**
+ * Get render context for a specific chart, merging workspace settings and chart profile.
+ */
+export function getChartContext(chartPath: string, environment: string): RenderContext {
+	const config = vscode.workspace.getConfiguration("chartProfiles");
+	const releaseName = config.get<string>("renderContext.releaseName");
+	const namespace = config.get<string>("renderContext.namespace");
+	return getChartRenderContext(releaseName, namespace, chartPath, environment);
 }
 
 /**

--- a/src/core/renderContextSettings.ts
+++ b/src/core/renderContextSettings.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure (VS Code–free) constants and helpers for the render context.
+ * Isolated from VS Code APIs so they can be unit-tested independently.
+ */
+
+/**
+ * Render context used during template rendering, visualization, validation, and comparison.
+ * This does NOT modify the chart itself — it only provides context for how the chart
+ * is rendered within the extension.
+ */
+export interface RenderContext {
+	/** Helm release name used in template rendering (e.g. `.Release.Name`) */
+	releaseName: string;
+	/** Kubernetes namespace passed to `helm template --namespace` */
+	namespace: string;
+}
+
+/** VS Code configuration key for the render-context release name */
+export const RENDER_CONTEXT_RELEASE_NAME_SETTING = "chartProfiles.renderContext.releaseName";
+
+/** VS Code configuration key for the render-context namespace */
+export const RENDER_CONTEXT_NAMESPACE_SETTING = "chartProfiles.renderContext.namespace";
+
+/** Default release name, matching Helm's own placeholder */
+export const DEFAULT_RELEASE_NAME = "RELEASE-NAME";
+
+/** Default namespace */
+export const DEFAULT_NAMESPACE = "default";
+
+/**
+ * Pure helper: build a RenderContext from raw configuration values.
+ * Returns defaults when the provided values are empty / undefined.
+ */
+export function buildRenderContext(releaseName: unknown, namespace: unknown): RenderContext {
+	return {
+		releaseName:
+			typeof releaseName === "string" && releaseName.trim() !== "" ? releaseName.trim() : DEFAULT_RELEASE_NAME,
+		namespace: typeof namespace === "string" && namespace.trim() !== "" ? namespace.trim() : DEFAULT_NAMESPACE,
+	};
+}

--- a/src/core/renderContextSettings.ts
+++ b/src/core/renderContextSettings.ts
@@ -3,6 +3,10 @@
  * Isolated from VS Code APIs so they can be unit-tested independently.
  */
 
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseYamlAsUnknown } from "../utils/yaml";
+
 /**
  * Render context used during template rendering, visualization, validation, and comparison.
  * This does NOT modify the chart itself — it only provides context for how the chart
@@ -21,11 +25,23 @@ export const RENDER_CONTEXT_RELEASE_NAME_SETTING = "chartProfiles.renderContext.
 /** VS Code configuration key for the render-context namespace */
 export const RENDER_CONTEXT_NAMESPACE_SETTING = "chartProfiles.renderContext.namespace";
 
-/** Default release name, matching Helm's own placeholder */
-export const DEFAULT_RELEASE_NAME = "RELEASE-NAME";
+/** Default release name, following Helm's naming conventions */
+export const DEFAULT_RELEASE_NAME = "chart-profile";
 
 /** Default namespace */
 export const DEFAULT_NAMESPACE = "default";
+
+/** Chart-level profile configuration file name */
+export const CHART_PROFILE_FILE = ".chart-profile.yaml";
+
+/**
+ * Chart-level profile configuration schema
+ */
+export interface ChartProfileConfig {
+	releaseName?: string;
+	namespace?: string;
+	environments?: Record<string, { releaseName?: string; namespace?: string }>;
+}
 
 /**
  * Pure helper: build a RenderContext from raw configuration values.
@@ -37,4 +53,67 @@ export function buildRenderContext(releaseName: unknown, namespace: unknown): Re
 			typeof releaseName === "string" && releaseName.trim() !== "" ? releaseName.trim() : DEFAULT_RELEASE_NAME,
 		namespace: typeof namespace === "string" && namespace.trim() !== "" ? namespace.trim() : DEFAULT_NAMESPACE,
 	};
+}
+
+/**
+ * Load chart-level profile configuration from .chart-profile.yaml
+ */
+export function loadChartProfile(chartPath: string): ChartProfileConfig | null {
+	const profilePath = path.join(chartPath, CHART_PROFILE_FILE);
+
+	try {
+		const content = fs.readFileSync(profilePath, "utf8");
+		const config = parseYamlAsUnknown(content);
+
+		if (config && typeof config === "object") {
+			return {
+				releaseName: typeof config.releaseName === "string" ? config.releaseName : undefined,
+				namespace: typeof config.namespace === "string" ? config.namespace : undefined,
+				environments:
+					typeof config.environments === "object" && config.environments !== null
+						? (config.environments as Record<string, { releaseName?: string; namespace?: string }>)
+						: undefined,
+			};
+		}
+	} catch {
+		// Profile file doesn't exist or can't be read - this is fine
+	}
+
+	return null;
+}
+
+/**
+ * Get render context for a specific chart and environment, merging
+ * workspace settings, chart profile, and defaults.
+ * 
+ * Precedence order (highest to lowest):
+ * 1. Workspace settings
+ * 2. Environment-specific profile settings
+ * 3. Chart-level profile defaults
+ * 4. Built-in defaults
+ */
+export function getChartRenderContext(
+	workspaceReleaseName: string | undefined,
+	workspaceNamespace: string | undefined,
+	chartPath: string,
+	environment: string,
+): RenderContext {
+	// Apply chart-level profile configuration
+	const chartProfile = loadChartProfile(chartPath);
+	let releaseName = workspaceReleaseName;
+	let namespace = workspaceNamespace;
+
+	if (chartProfile) {
+		// Check for environment-specific overrides first (these have priority over chart defaults)
+		if (chartProfile.environments?.[environment]) {
+			const envConfig = chartProfile.environments[environment];
+			releaseName = releaseName ?? envConfig.releaseName;
+			namespace = namespace ?? envConfig.namespace;
+		}
+		// Apply chart-level defaults (lowest priority)
+		releaseName = releaseName ?? chartProfile.releaseName;
+		namespace = namespace ?? chartProfile.namespace;
+	}
+
+	return buildRenderContext(releaseName, namespace);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { getKubernetesConnector } from "./k8s/kubernetesConnector";
 import { createChartValidator } from "./processing/chartValidator";
 import { getRuntimeStateManager } from "./state/runtimeStateManager";
 import { showRenderedYaml } from "./utils/renderedYamlView";
+import { promptRenderContext } from "./core/renderContext";
 import {
 	exportComparisonReport,
 	show as showChartVisualization,
@@ -260,6 +261,19 @@ export function activate(context: vscode.ExtensionContext) {
 		await showFirstRunWalkthrough(context, /* forceShow */ true);
 	});
 
+	// Register configure render context command
+	const configureRenderContextCommand = vscode.commands.registerCommand(
+		"chartProfiles.configureRenderContext",
+		async () => {
+			const result = await promptRenderContext();
+			if (result) {
+				vscode.window.showInformationMessage(
+					`Render context updated — Release Name: "${result.releaseName}", Namespace: "${result.namespace}"`
+				);
+			}
+		}
+	);
+
 	// Register update dependencies command
 	const updateDependenciesCommand = vscode.commands.registerCommand(
 		"chartProfiles.updateDependencies",
@@ -301,6 +315,7 @@ export function activate(context: vscode.ExtensionContext) {
 		compareEnvironmentsCommand,
 		exportComparisonReportCommand,
 		startWalkthroughCommand,
+		configureRenderContextCommand,
 		updateDependenciesCommand
 	);
 

--- a/src/k8s/helmRenderer.ts
+++ b/src/k8s/helmRenderer.ts
@@ -35,14 +35,15 @@ export interface RenderedResource {
 export async function renderHelmTemplate(
 	chartPath: string,
 	environment: string,
-	releaseName = "release"
+	releaseName = "RELEASE-NAME",
+	namespace = "default"
 ): Promise<RenderedResource[]> {
 	// Check if helm is available
 	const helmAvailable = await isHelmAvailable();
 
 	if (!helmAvailable) {
 		console.warn("Helm CLI not found. Using placeholder rendering.");
-		return await getPlaceholderResources(chartPath, environment);
+		return await getPlaceholderResources(chartPath, environment, releaseName);
 	}
 
 	// Keep a printable command preview for diagnostics
@@ -50,10 +51,10 @@ export async function renderHelmTemplate(
 
 	try {
 		// Build helm template args
-		// helm template [RELEASE_NAME] [CHART] -f values.yaml -f values-<env>.yaml
+		// helm template [RELEASE_NAME] [CHART] --namespace [NAMESPACE] -f values.yaml -f values-<env>.yaml
 		const baseValuesPath = path.join(chartPath, "values.yaml");
 		const envValuesPath = path.join(chartPath, `values-${environment}.yaml`);
-		const args: string[] = ["template", releaseName, chartPath];
+		const args: string[] = ["template", releaseName, chartPath, "--namespace", namespace];
 
 		if (fs.existsSync(baseValuesPath)) {
 			args.push("-f", baseValuesPath);
@@ -244,7 +245,7 @@ export async function isHelmAvailable(): Promise<boolean> {
 /**
  * Returns fallback resources when Helm is not available by reading and partially rendering template files
  */
-async function getPlaceholderResources(chartPath: string, environment: string): Promise<RenderedResource[]> {
+async function getPlaceholderResources(chartPath: string, environment: string, releaseName = "RELEASE-NAME"): Promise<RenderedResource[]> {
 	const chartName = path.basename(chartPath);
 	const templatesDir = path.join(chartPath, "templates");
 	const resources: RenderedResource[] = [];
@@ -301,8 +302,6 @@ async function getPlaceholderResources(chartPath: string, environment: string): 
 			let templateContent = await fs.promises.readFile(templatePath, "utf8");
 
 			// Perform basic Go template variable substitution
-			const releaseName = `${chartName}-${environment}`;
-
 			// Replace common template variables using defined patterns
 			templateContent = templateContent
 				.replace(TEMPLATE_PATTERNS.RELEASE_NAME, releaseName)

--- a/src/k8s/helmRenderer.ts
+++ b/src/k8s/helmRenderer.ts
@@ -35,7 +35,7 @@ export interface RenderedResource {
 export async function renderHelmTemplate(
 	chartPath: string,
 	environment: string,
-	releaseName = "RELEASE-NAME",
+	releaseName = "chart-profile",
 	namespace = "default"
 ): Promise<RenderedResource[]> {
 	// Check if helm is available
@@ -245,7 +245,7 @@ export async function isHelmAvailable(): Promise<boolean> {
 /**
  * Returns fallback resources when Helm is not available by reading and partially rendering template files
  */
-async function getPlaceholderResources(chartPath: string, environment: string, releaseName = "RELEASE-NAME"): Promise<RenderedResource[]> {
+async function getPlaceholderResources(chartPath: string, environment: string, releaseName = "chart-profile"): Promise<RenderedResource[]> {
 	const chartName = path.basename(chartPath);
 	const templatesDir = path.join(chartPath, "templates");
 	const resources: RenderedResource[] = [];

--- a/src/processing/chartValidator.ts
+++ b/src/processing/chartValidator.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
-import { getRenderContext } from "../core/renderContext";
+import { getRenderContext, getChartContext } from "../core/renderContext";
 import { isHelmAvailable, type RenderedResource, renderHelmTemplate } from "../k8s/helmRenderer";
 import { getKubernetesConnector } from "../k8s/kubernetesConnector";
 import { runHelm } from "../utils/cliRunner";
@@ -48,7 +48,7 @@ export class ChartValidator {
 
 		let resources: RenderedResource[] = [];
 		try {
-			const renderContext = getRenderContext();
+			const renderContext = getChartContext(this.chartPath, environment);
 			resources = await renderHelmTemplate(this.chartPath, environment, renderContext.releaseName, renderContext.namespace);
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -625,8 +625,10 @@ export class ChartValidator {
 		const issues: ValidationIssue[] = [];
 
 		try {
-			const fromResources = await renderHelmTemplate(this.chartPath, fromEnvironment);
-			const toResources = await renderHelmTemplate(this.chartPath, toEnvironment);
+			const fromContext = getChartContext(this.chartPath, fromEnvironment);
+			const toContext = getChartContext(this.chartPath, toEnvironment);
+			const fromResources = await renderHelmTemplate(this.chartPath, fromEnvironment, fromContext.releaseName, fromContext.namespace);
+			const toResources = await renderHelmTemplate(this.chartPath, toEnvironment, toContext.releaseName, toContext.namespace);
 
 			const connector = getKubernetesConnector();
 

--- a/src/processing/chartValidator.ts
+++ b/src/processing/chartValidator.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
+import { getRenderContext } from "../core/renderContext";
 import { isHelmAvailable, type RenderedResource, renderHelmTemplate } from "../k8s/helmRenderer";
 import { getKubernetesConnector } from "../k8s/kubernetesConnector";
 import { runHelm } from "../utils/cliRunner";
@@ -47,7 +48,8 @@ export class ChartValidator {
 
 		let resources: RenderedResource[] = [];
 		try {
-			resources = await renderHelmTemplate(this.chartPath, environment);
+			const renderContext = getRenderContext();
+			resources = await renderHelmTemplate(this.chartPath, environment, renderContext.releaseName, renderContext.namespace);
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			issues.push({

--- a/src/state/runtimeStateManager.ts
+++ b/src/state/runtimeStateManager.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { renderHelmTemplate } from "../k8s/helmRenderer";
+import { getChartContext } from "../core/renderContext";
 import {
 	type ClusterInfo,
 	type HelmRelease,
@@ -110,7 +111,8 @@ export class RuntimeStateManager {
 
 		// Render chart to get expected resources
 		try {
-			const renderedResources = await renderHelmTemplate(chartPath, environment);
+			const renderContext = getChartContext(chartPath, environment);
+			const renderedResources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 
 			// Get runtime state for each resource
 			for (const resource of renderedResources) {
@@ -299,8 +301,9 @@ export class RuntimeStateManager {
 		// Get deployed resource
 		const deployed = await this.getResourceYaml(kind, name, namespace);
 
-		// Get rendered resource
-		const resources = await renderHelmTemplate(chartPath, environment);
+		// Get rendered resource with chart-specific context
+		const renderContext = getChartContext(chartPath, environment);
+		const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 		const resource = resources.find((r) => r.kind === kind && r.name === name);
 
 		const rendered = resource?.yaml || "";

--- a/src/utils/renderedYamlView.ts
+++ b/src/utils/renderedYamlView.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import type { ChartTreeItem } from "../core/chartProfilesProvider";
+import { getRenderContext } from "../core/renderContext";
 import { renderHelmTemplate, type RenderedResource } from "../k8s/helmRenderer";
 import { generateAnnotatedYaml, mergeValues } from "../processing/valuesMerger";
 
@@ -109,9 +110,9 @@ async function showRenderedTemplates(chartPath: string, environment: string, cha
 		async (progress) => {
 			progress.report({ increment: 0 });
 
-			// Render templates
-			const releaseName = `${chartName}-${environment}`;
-			const resources = await renderHelmTemplate(chartPath, environment, releaseName);
+			// Render templates using render context from workspace settings
+			const renderContext = getRenderContext();
+			const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 
 			progress.report({ increment: 50 });
 

--- a/src/utils/renderedYamlView.ts
+++ b/src/utils/renderedYamlView.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import type { ChartTreeItem } from "../core/chartProfilesProvider";
-import { getRenderContext } from "../core/renderContext";
+import { getRenderContext, getChartContext } from "../core/renderContext";
 import { renderHelmTemplate, type RenderedResource } from "../k8s/helmRenderer";
 import { generateAnnotatedYaml, mergeValues } from "../processing/valuesMerger";
 
@@ -110,8 +110,8 @@ async function showRenderedTemplates(chartPath: string, environment: string, cha
 		async (progress) => {
 			progress.report({ increment: 0 });
 
-			// Render templates using render context from workspace settings
-			const renderContext = getRenderContext();
+			// Render templates using chart-specific context
+			const renderContext = getChartContext(chartPath, environment);
 			const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 
 			progress.report({ increment: 50 });

--- a/src/visualization/chartVisualizationView.ts
+++ b/src/visualization/chartVisualizationView.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import * as yaml from "js-yaml";
 import * as vscode from "vscode";
 import type { ChartTreeItem } from "../core/chartProfilesProvider";
-import { getRenderContext } from "../core/renderContext";
+import { getRenderContext, getChartContext } from "../core/renderContext";
 import { type ComparisonWebviewData, compareEnvironments, formatComparisonForWebview } from "../diff/environmentDiff";
 import { type RenderedResource, renderHelmTemplate } from "../k8s/helmRenderer";
 import { getKubernetesConnector } from "../k8s/kubernetesConnector";
@@ -612,9 +612,10 @@ async function handleMessage(message: WebviewMessage) {
 
 					vscode.window.showInformationMessage(`Re-running comparison: ${leftEnv} vs ${rightEnv}...`);
 
-					const renderContext = getRenderContext();
-					const resources1 = await renderHelmTemplate(chartPath, leftEnv, renderContext.releaseName, renderContext.namespace);
-					const resources2 = await renderHelmTemplate(chartPath, rightEnv, renderContext.releaseName, renderContext.namespace);
+					const renderContext1 = getChartContext(chartPath, leftEnv);
+					const renderContext2 = getChartContext(chartPath, rightEnv);
+					const resources1 = await renderHelmTemplate(chartPath, leftEnv, renderContext1.releaseName, renderContext1.namespace);
+					const resources2 = await renderHelmTemplate(chartPath, rightEnv, renderContext2.releaseName, renderContext2.namespace);
 
 					const comparison = compareEnvironments(leftEnv, resources1, rightEnv, resources2, chartName);
 					const comparisonData = formatComparisonForWebview(comparison);
@@ -691,9 +692,10 @@ async function runComparisonFromWebview(env1: string, env2: string): Promise<voi
 	try {
 		vscode.window.showInformationMessage(`Comparing ${env1} vs ${env2}...`);
 
-		const renderContext = getRenderContext();
-		const resources1 = await renderHelmTemplate(chartPath, env1, renderContext.releaseName, renderContext.namespace);
-		const resources2 = await renderHelmTemplate(chartPath, env2, renderContext.releaseName, renderContext.namespace);
+		const renderContext1 = getChartContext(chartPath, env1);
+		const renderContext2 = getChartContext(chartPath, env2);
+		const resources1 = await renderHelmTemplate(chartPath, env1, renderContext1.releaseName, renderContext1.namespace);
+		const resources2 = await renderHelmTemplate(chartPath, env2, renderContext2.releaseName, renderContext2.namespace);
 
 		const comparison = compareEnvironments(env1, resources1, env2, resources2, chartName);
 		const comparisonData = formatComparisonForWebview(comparison);
@@ -1113,7 +1115,7 @@ async function collectChartDataCore(params: CollectChartDataParams): Promise<{
 	let resources: RenderedResource[] = [];
 
 	try {
-		const renderContext = getRenderContext();
+		const renderContext = getChartContext(chartPath, environment);
 		resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 		renderedResources = resources;
 

--- a/src/visualization/chartVisualizationView.ts
+++ b/src/visualization/chartVisualizationView.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as yaml from "js-yaml";
 import * as vscode from "vscode";
 import type { ChartTreeItem } from "../core/chartProfilesProvider";
+import { getRenderContext } from "../core/renderContext";
 import { type ComparisonWebviewData, compareEnvironments, formatComparisonForWebview } from "../diff/environmentDiff";
 import { type RenderedResource, renderHelmTemplate } from "../k8s/helmRenderer";
 import { getKubernetesConnector } from "../k8s/kubernetesConnector";
@@ -611,11 +612,9 @@ async function handleMessage(message: WebviewMessage) {
 
 					vscode.window.showInformationMessage(`Re-running comparison: ${leftEnv} vs ${rightEnv}...`);
 
-					const releaseName1 = `${chartName}-${leftEnv}`;
-					const releaseName2 = `${chartName}-${rightEnv}`;
-
-					const resources1 = await renderHelmTemplate(chartPath, leftEnv, releaseName1);
-					const resources2 = await renderHelmTemplate(chartPath, rightEnv, releaseName2);
+					const renderContext = getRenderContext();
+					const resources1 = await renderHelmTemplate(chartPath, leftEnv, renderContext.releaseName, renderContext.namespace);
+					const resources2 = await renderHelmTemplate(chartPath, rightEnv, renderContext.releaseName, renderContext.namespace);
 
 					const comparison = compareEnvironments(leftEnv, resources1, rightEnv, resources2, chartName);
 					const comparisonData = formatComparisonForWebview(comparison);
@@ -692,11 +691,9 @@ async function runComparisonFromWebview(env1: string, env2: string): Promise<voi
 	try {
 		vscode.window.showInformationMessage(`Comparing ${env1} vs ${env2}...`);
 
-		const releaseName1 = `${chartName}-${env1}`;
-		const releaseName2 = `${chartName}-${env2}`;
-
-		const resources1 = await renderHelmTemplate(chartPath, env1, releaseName1);
-		const resources2 = await renderHelmTemplate(chartPath, env2, releaseName2);
+		const renderContext = getRenderContext();
+		const resources1 = await renderHelmTemplate(chartPath, env1, renderContext.releaseName, renderContext.namespace);
+		const resources2 = await renderHelmTemplate(chartPath, env2, renderContext.releaseName, renderContext.namespace);
 
 		const comparison = compareEnvironments(env1, resources1, env2, resources2, chartName);
 		const comparisonData = formatComparisonForWebview(comparison);
@@ -1116,8 +1113,8 @@ async function collectChartDataCore(params: CollectChartDataParams): Promise<{
 	let resources: RenderedResource[] = [];
 
 	try {
-		const releaseName = `${chartName}-${environment}`;
-		resources = await renderHelmTemplate(chartPath, environment, releaseName);
+		const renderContext = getRenderContext();
+		resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
 		renderedResources = resources;
 
 		resources.forEach((resource) => {

--- a/test/renderContext.test.js
+++ b/test/renderContext.test.js
@@ -7,12 +7,16 @@
  */
 
 const assert = require("assert");
+const path = require("node:path");
+const fs = require("node:fs");
 const {
 	buildRenderContext,
 	DEFAULT_RELEASE_NAME,
 	DEFAULT_NAMESPACE,
 	RENDER_CONTEXT_RELEASE_NAME_SETTING,
 	RENDER_CONTEXT_NAMESPACE_SETTING,
+	loadChartProfile,
+	getChartRenderContext,
 } = require("../out/test-modules/core/renderContextSettings");
 
 let passed = 0;
@@ -39,8 +43,8 @@ function test(name, fn) {
 
 console.log("\nDefault values:");
 
-test("DEFAULT_RELEASE_NAME is RELEASE-NAME", () => {
-	assert.strictEqual(DEFAULT_RELEASE_NAME, "RELEASE-NAME");
+test("DEFAULT_RELEASE_NAME is chart-profile", () => {
+	assert.strictEqual(DEFAULT_RELEASE_NAME, "chart-profile");
 });
 
 test("DEFAULT_NAMESPACE is default", () => {
@@ -63,7 +67,7 @@ test("trims whitespace from releaseName", () => {
 });
 
 test("trims whitespace from namespace", () => {
-	const ctx = buildRenderContext("RELEASE-NAME", "  staging  ");
+	const ctx = buildRenderContext("chart-profile", "  staging  ");
 	assert.strictEqual(ctx.namespace, "staging");
 });
 
@@ -92,17 +96,17 @@ test("falls back to DEFAULT_RELEASE_NAME when releaseName is null", () => {
 });
 
 test("falls back to DEFAULT_NAMESPACE when namespace is empty string", () => {
-	const ctx = buildRenderContext("RELEASE-NAME", "");
+	const ctx = buildRenderContext("my-release", "");
 	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
 });
 
 test("falls back to DEFAULT_NAMESPACE when namespace is whitespace only", () => {
-	const ctx = buildRenderContext("RELEASE-NAME", "   ");
+	const ctx = buildRenderContext("my-release", "   ");
 	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
 });
 
 test("falls back to DEFAULT_NAMESPACE when namespace is undefined", () => {
-	const ctx = buildRenderContext("RELEASE-NAME", undefined);
+	const ctx = buildRenderContext("my-release", undefined);
 	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
 });
 
@@ -130,6 +134,105 @@ test("RENDER_CONTEXT_RELEASE_NAME_SETTING contains 'releaseName'", () => {
 
 test("RENDER_CONTEXT_NAMESPACE_SETTING contains 'namespace'", () => {
 	assert.ok(RENDER_CONTEXT_NAMESPACE_SETTING.includes("namespace"));
+});
+
+// ── Chart Profile Configuration Tests ───────────────────────────────────────────
+
+console.log("\nChart Profile Configuration:");
+
+test("loadChartProfile returns null for non-existent file", () => {
+	const profile = loadChartProfile("/nonexistent/chart/path");
+	assert.strictEqual(profile, null);
+});
+
+test("loadChartProfile parses valid chart profile", () => {
+	const tempDir = path.join(__dirname, "temp-profile-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, "releaseName: my-release\nnamespace: my-namespace\n");
+
+	const profile = loadChartProfile(tempDir);
+	assert.strictEqual(profile.releaseName, "my-release");
+	assert.strictEqual(profile.namespace, "my-namespace");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("loadChartProfile parses environment-specific settings", () => {
+	const tempDir = path.join(__dirname, "temp-profile-env-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, `
+releaseName: default-release
+namespace: default-ns
+environments:
+  dev:
+    releaseName: dev-release
+    namespace: dev-ns
+  prod:
+    releaseName: prod-release
+`);
+
+	const profile = loadChartProfile(tempDir);
+	assert.strictEqual(profile.releaseName, "default-release");
+	assert.strictEqual(profile.namespace, "default-ns");
+	assert.strictEqual(profile.environments.dev.releaseName, "dev-release");
+	assert.strictEqual(profile.environments.dev.namespace, "dev-ns");
+	assert.strictEqual(profile.environments.prod.releaseName, "prod-release");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext uses workspace settings as base", () => {
+	const ctx = getChartRenderContext("workspace-release", "workspace-ns", "/some/chart", "dev");
+	assert.strictEqual(ctx.releaseName, "workspace-release");
+	assert.strictEqual(ctx.namespace, "workspace-ns");
+});
+
+test("getChartRenderContext applies chart profile overrides", () => {
+	const tempDir = path.join(__dirname, "temp-profile-override-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, "releaseName: chart-release\nnamespace: chart-ns\n");
+
+	const ctx = getChartRenderContext(undefined, undefined, tempDir, "dev");
+	assert.strictEqual(ctx.releaseName, "chart-release");
+	assert.strictEqual(ctx.namespace, "chart-ns");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext applies environment-specific overrides", () => {
+	const tempDir = path.join(__dirname, "temp-profile-env-override-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, `
+releaseName: default-release
+namespace: default-ns
+environments:
+  dev:
+    releaseName: dev-release
+    namespace: dev-ns
+`);
+
+	const ctx = getChartRenderContext(undefined, undefined, tempDir, "dev");
+	assert.strictEqual(ctx.releaseName, "dev-release");
+	assert.strictEqual(ctx.namespace, "dev-ns");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext workspace settings take precedence over chart defaults", () => {
+	const tempDir = path.join(__dirname, "temp-profile-prec-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, "releaseName: chart-release\nnamespace: chart-ns\n");
+
+	const ctx = getChartRenderContext("workspace-release", undefined, tempDir, "dev");
+	assert.strictEqual(ctx.releaseName, "workspace-release");
+	assert.strictEqual(ctx.namespace, "chart-ns");
+
+	fs.rmSync(tempDir, { recursive: true });
 });
 
 // ── Summary ──────────────────────────────────────────────────────────────────

--- a/test/renderContext.test.js
+++ b/test/renderContext.test.js
@@ -1,0 +1,140 @@
+// @ts-check
+/**
+ * Unit tests for buildRenderContext — the pure helper that assembles a
+ * RenderContext from raw configuration values.
+ *
+ * Run with: node test/renderContext.test.js
+ */
+
+const assert = require("assert");
+const {
+	buildRenderContext,
+	DEFAULT_RELEASE_NAME,
+	DEFAULT_NAMESPACE,
+	RENDER_CONTEXT_RELEASE_NAME_SETTING,
+	RENDER_CONTEXT_NAMESPACE_SETTING,
+} = require("../out/test-modules/core/renderContextSettings");
+
+let passed = 0;
+let failed = 0;
+
+/**
+ * Simple test runner helper.
+ * @param {string} name
+ * @param {() => void} fn
+ */
+function test(name, fn) {
+	try {
+		fn();
+		console.log(`  ✔ ${name}`);
+		passed++;
+	} catch (err) {
+		console.error(`  ✘ ${name}`);
+		console.error(`      ${err.message}`);
+		failed++;
+	}
+}
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+console.log("\nDefault values:");
+
+test("DEFAULT_RELEASE_NAME is RELEASE-NAME", () => {
+	assert.strictEqual(DEFAULT_RELEASE_NAME, "RELEASE-NAME");
+});
+
+test("DEFAULT_NAMESPACE is default", () => {
+	assert.strictEqual(DEFAULT_NAMESPACE, "default");
+});
+
+// ── buildRenderContext with valid inputs ─────────────────────────────────────
+
+console.log("\nbuildRenderContext with valid inputs:");
+
+test("uses provided releaseName and namespace", () => {
+	const ctx = buildRenderContext("my-release", "production");
+	assert.strictEqual(ctx.releaseName, "my-release");
+	assert.strictEqual(ctx.namespace, "production");
+});
+
+test("trims whitespace from releaseName", () => {
+	const ctx = buildRenderContext("  my-release  ", "default");
+	assert.strictEqual(ctx.releaseName, "my-release");
+});
+
+test("trims whitespace from namespace", () => {
+	const ctx = buildRenderContext("RELEASE-NAME", "  staging  ");
+	assert.strictEqual(ctx.namespace, "staging");
+});
+
+// ── buildRenderContext with empty / falsy inputs ──────────────────────────────
+
+console.log("\nbuildRenderContext with empty / falsy inputs:");
+
+test("falls back to DEFAULT_RELEASE_NAME when releaseName is empty string", () => {
+	const ctx = buildRenderContext("", "default");
+	assert.strictEqual(ctx.releaseName, DEFAULT_RELEASE_NAME);
+});
+
+test("falls back to DEFAULT_RELEASE_NAME when releaseName is whitespace only", () => {
+	const ctx = buildRenderContext("   ", "default");
+	assert.strictEqual(ctx.releaseName, DEFAULT_RELEASE_NAME);
+});
+
+test("falls back to DEFAULT_RELEASE_NAME when releaseName is undefined", () => {
+	const ctx = buildRenderContext(undefined, "default");
+	assert.strictEqual(ctx.releaseName, DEFAULT_RELEASE_NAME);
+});
+
+test("falls back to DEFAULT_RELEASE_NAME when releaseName is null", () => {
+	const ctx = buildRenderContext(null, "default");
+	assert.strictEqual(ctx.releaseName, DEFAULT_RELEASE_NAME);
+});
+
+test("falls back to DEFAULT_NAMESPACE when namespace is empty string", () => {
+	const ctx = buildRenderContext("RELEASE-NAME", "");
+	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
+});
+
+test("falls back to DEFAULT_NAMESPACE when namespace is whitespace only", () => {
+	const ctx = buildRenderContext("RELEASE-NAME", "   ");
+	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
+});
+
+test("falls back to DEFAULT_NAMESPACE when namespace is undefined", () => {
+	const ctx = buildRenderContext("RELEASE-NAME", undefined);
+	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
+});
+
+test("falls back to both defaults when both inputs are undefined", () => {
+	const ctx = buildRenderContext(undefined, undefined);
+	assert.strictEqual(ctx.releaseName, DEFAULT_RELEASE_NAME);
+	assert.strictEqual(ctx.namespace, DEFAULT_NAMESPACE);
+});
+
+// ── Exported setting constants ───────────────────────────────────────────────
+
+console.log("\nExported setting constants:");
+
+test("RENDER_CONTEXT_RELEASE_NAME_SETTING contains 'chartProfiles'", () => {
+	assert.ok(RENDER_CONTEXT_RELEASE_NAME_SETTING.includes("chartProfiles"));
+});
+
+test("RENDER_CONTEXT_NAMESPACE_SETTING contains 'chartProfiles'", () => {
+	assert.ok(RENDER_CONTEXT_NAMESPACE_SETTING.includes("chartProfiles"));
+});
+
+test("RENDER_CONTEXT_RELEASE_NAME_SETTING contains 'releaseName'", () => {
+	assert.ok(RENDER_CONTEXT_RELEASE_NAME_SETTING.includes("releaseName"));
+});
+
+test("RENDER_CONTEXT_NAMESPACE_SETTING contains 'namespace'", () => {
+	assert.ok(RENDER_CONTEXT_NAMESPACE_SETTING.includes("namespace"));
+});
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+	process.exit(1);
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -10,6 +10,7 @@
 		"src/diff/environmentDiff.ts",
 		"src/k8s/helmRenderer.ts",
 		"src/k8s/kubernetesConnector.ts",
-		"src/core/walkthroughSettings.ts"
+		"src/core/walkthroughSettings.ts",
+		"src/core/renderContextSettings.ts"
 	]
 }


### PR DESCRIPTION
Fixed the invalid default Helm release name `RELEASE-NAME` (which fails Helm's naming validation) and added support for per-chart configuration via `.chart-profile.yaml`.

## Changes

### Bug Fix
- Changed default release name from `RELEASE-NAME` to `chart-profile` (validates against Helm's regex `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
- Updated all default parameters, tests, and package.json settings

### New Feature: Per-Chart Configuration
- Added `.chart-profile.yaml` support for chart-specific release names and namespaces
- Supports environment-specific overrides (dev, staging, prod, etc.)
- Precedence order: Workspace settings > Environment profile > Chart profile > Built-in defaults

## Usage

Create `.chart-profile.yaml` in your chart directory:
```yaml
releaseName: my-app
namespace: my-app
environments:
  dev:
    releaseName: my-app-dev
    namespace: dev
```