### PR TITLE
correct Helm release lookup and extend template render fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,38 @@ VS Code extension for visualizing, validating, comparing, and monitoring Helm ch
 
 ## Chart-Specific Configuration
 
-Add `.chart-profile.yaml` in your chart directory to configure release name and namespace per environment:
+Add `.chart-profile.yaml` in your chart directory to configure how `helm template` is invoked, per environment:
 
 ```yaml
 # Default values
 releaseName: my-app
 namespace: my-app
 
+# Extra `helm template` flags, applied on top of values.yaml / values-<env>.yaml
+valuesFiles:
+  - values-common.yaml       # extra -f files, relative to the chart directory
+setValues:
+  - "global.region=us-east"  # --set overrides
+apiVersions:
+  - "networking.k8s.io/v1/Ingress"  # --api-versions, for .Capabilities.APIVersions checks
+kubeVersion: "1.29.0"         # --kube-version, for .Capabilities.KubeVersion checks
+
 # Environment overrides
 environments:
   dev:
     releaseName: my-app-dev
     namespace: dev
+    setValues:
+      - "replicaCount=1"
   prod:
     releaseName: my-app
     namespace: production
 ```
 
-**Precedence order** (highest to lowest):
-1. Workspace settings
+`releaseName` and `namespace` can also be set via workspace settings; `valuesFiles`, `setValues`, `apiVersions`, and `kubeVersion` are only read from `.chart-profile.yaml`.
+
+**Precedence order** (highest to lowest), applied independently per field:
+1. Workspace settings (`releaseName` / `namespace` only)
 2. Environment-specific profile
 3. Chart-level profile
 4. Built-in defaults

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"files": {
 		"includes": ["src/**/*.ts", "test/**/*.js"]
 	},
@@ -25,7 +25,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"complexity": {
 				"noStaticOnlyClass": "off",
 				"noForEach": "off",

--- a/examples/sample-app/.chart-profile.yaml
+++ b/examples/sample-app/.chart-profile.yaml
@@ -2,11 +2,13 @@
 # This file defines chart-specific rendering context settings
 
 # Default release name and namespace for this chart
-releaseName: sample-app
-namespace: sample-app
+
 
 # Environment-specific overrides
 environments:
+  default:
+    releaseName: sample-app-dev
+    namespace: dev
   dev:
     releaseName: sample-app-dev
     namespace: dev

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart-profile-visualizer",
   "displayName": "Helm Chart Visualizer",
   "description": "Visualize Helm charts across environments with value merging and template rendering",
-  "version": "0.0.9",
+  "version": "0.10.0",
   "publisher": "nomad-in-code",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "url": "https://github.com/chaluvadis/chart-profile-visualizer/issues"
   },
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.125.0"
   },
   "categories": [
     "Other",
@@ -199,17 +199,17 @@
     "test": "tsc -p tsconfig.test.json && node test/driftSeverity.test.js && node test/kubectlDetection.test.js && node test/firstRunWalkthrough.test.js && node test/renderContext.test.js"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.14",
+    "@biomejs/biome": "^2.5.2",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^25.6.2",
-    "@types/vscode": "^1.110.0",
-    "@vscode/vsce": "^3.9.1",
-    "esbuild": "^0.28.0",
+    "@types/node": "^26.1.0",
+    "@types/vscode": "^1.125.0",
+    "@vscode/vsce": "^3.9.2",
+    "esbuild": "^0.28.1",
     "typescript": "^6.0.3"
   },
   "dependencies": {
     "chart.js": "^4.5.1",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^5.2.1"
   },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,27 +12,27 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^5.2.1
+        version: 5.2.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.14
-        version: 2.4.14
+        specifier: ^2.5.2
+        version: 2.5.2
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^25.6.2
-        version: 25.6.2
+        specifier: ^26.1.0
+        version: 26.1.0
       '@types/vscode':
-        specifier: ^1.110.0
-        version: 1.118.0
+        specifier: ^1.125.0
+        version: 1.125.0
       '@vscode/vsce':
-        specifier: ^3.9.1
-        version: 3.9.1
+        specifier: ^3.9.2
+        version: 3.9.2
       esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
+        specifier: ^0.28.1
+        version: 0.28.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -97,222 +97,218 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.14':
-    resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
+  '@biomejs/biome@2.5.2':
+    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
-    resolution: {integrity: sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==}
+  '@biomejs/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.14':
-    resolution: {integrity: sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==}
+  '@biomejs/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
-    resolution: {integrity: sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==}
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.14':
-    resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
+  '@biomejs/cli-linux-arm64@2.5.2':
+    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
-    resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
+  '@biomejs/cli-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.14':
-    resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
+  '@biomejs/cli-linux-x64@2.5.2':
+    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.14':
-    resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
+  '@biomejs/cli-win32-arm64@2.5.2':
+    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.14':
-    resolution: {integrity: sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==}
+  '@biomejs/cli-win32-x64@2.5.2':
+    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
@@ -396,8 +392,8 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
-  '@types/node@25.6.2':
-    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -405,8 +401,8 @@ packages:
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
-  '@types/vscode@1.118.0':
-    resolution: {integrity: sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==}
+  '@types/vscode@1.125.0':
+    resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
 
   '@typespec/ts-http-runtime@0.3.5':
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
@@ -460,8 +456,8 @@ packages:
   '@vscode/vsce-sign@2.0.9':
     resolution: {integrity: sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==}
 
-  '@vscode/vsce@3.9.1':
-    resolution: {integrity: sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==}
+  '@vscode/vsce@3.9.2':
+    resolution: {integrity: sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -501,9 +497,6 @@ packages:
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -523,9 +516,6 @@ packages:
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
-
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -596,13 +586,6 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -713,8 +696,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -738,10 +721,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -772,11 +751,9 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
@@ -875,22 +852,19 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1005,9 +979,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1060,9 +1031,6 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -1078,10 +1046,6 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -1186,14 +1150,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -1209,10 +1165,6 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -1328,8 +1280,8 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -1368,11 +1320,6 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1497,120 +1444,118 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@biomejs/biome@2.4.14':
+  '@biomejs/biome@2.5.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.14
-      '@biomejs/cli-darwin-x64': 2.4.14
-      '@biomejs/cli-linux-arm64': 2.4.14
-      '@biomejs/cli-linux-arm64-musl': 2.4.14
-      '@biomejs/cli-linux-x64': 2.4.14
-      '@biomejs/cli-linux-x64-musl': 2.4.14
-      '@biomejs/cli-win32-arm64': 2.4.14
-      '@biomejs/cli-win32-x64': 2.4.14
+      '@biomejs/cli-darwin-arm64': 2.5.2
+      '@biomejs/cli-darwin-x64': 2.5.2
+      '@biomejs/cli-linux-arm64': 2.5.2
+      '@biomejs/cli-linux-arm64-musl': 2.5.2
+      '@biomejs/cli-linux-x64': 2.5.2
+      '@biomejs/cli-linux-x64-musl': 2.5.2
+      '@biomejs/cli-win32-arm64': 2.5.2
+      '@biomejs/cli-win32-x64': 2.5.2
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
+  '@biomejs/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.14':
+  '@biomejs/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.14':
+  '@biomejs/cli-linux-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
+  '@biomejs/cli-linux-x64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.14':
+  '@biomejs/cli-linux-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.14':
+  '@biomejs/cli-win32-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.14':
+  '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.0':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.28.0':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.0':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.0':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.0':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.0':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
-
-  '@isaacs/cliui@9.0.0': {}
 
   '@kurkle/color@0.3.4': {}
 
@@ -1733,15 +1678,15 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/node@25.6.2':
+  '@types/node@26.1.0':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 8.3.0
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/sarif@2.1.7': {}
 
-  '@types/vscode@1.118.0': {}
+  '@types/vscode@1.125.0': {}
 
   '@typespec/ts-http-runtime@0.3.5':
     dependencies:
@@ -1790,7 +1735,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.9.1':
+  '@vscode/vsce@3.9.2':
     dependencies:
       '@azure/identity': 4.13.1
       '@secretlint/node': 10.2.2
@@ -1804,13 +1749,13 @@ snapshots:
       cockatiel: 3.2.1
       commander: 12.1.0
       form-data: 4.0.5
-      glob: 11.1.0
+      glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
       leven: 3.1.0
       markdown-it: 14.1.1
       mime: 1.6.0
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       parse-semver: 1.1.1
       read: 1.0.7
       secretlint: 10.2.2
@@ -1858,8 +1803,6 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1:
@@ -1879,11 +1822,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
-
-  brace-expansion@1.1.14:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -1967,14 +1905,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@12.1.0: {}
-
-  concat-map@0.0.1: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2079,34 +2009,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.3
 
-  esbuild@0.28.0:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   expand-template@2.0.3:
     optional: true
@@ -2130,11 +2060,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
   form-data@4.0.5:
     dependencies:
@@ -2180,13 +2105,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@11.1.0:
+  glob@13.0.6:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
       minimatch: 10.2.5
       minipass: 7.1.3
-      package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   globby@14.1.0:
@@ -2280,21 +2202,19 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
-  isexe@2.0.0: {}
-
   istextorbinary@9.5.0:
     dependencies:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
 
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
-
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2407,10 +2327,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.14
-
   minimist@1.2.8:
     optional: true
 
@@ -2465,8 +2381,6 @@ snapshots:
 
   p-map@7.0.4: {}
 
-  package-json-from-dist@1.0.1: {}
-
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2489,8 +2403,6 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
-
-  path-key@3.1.1: {}
 
   path-scurry@2.0.2:
     dependencies:
@@ -2607,12 +2519,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -2640,8 +2546,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-
-  signal-exit@4.1.0: {}
 
   simple-concat@1.0.1:
     optional: true
@@ -2775,7 +2679,7 @@ snapshots:
 
   underscore@1.13.8: {}
 
-  undici-types@7.19.2: {}
+  undici-types@8.3.0: {}
 
   undici@7.25.0: {}
 
@@ -2802,10 +2706,6 @@ snapshots:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
 
   wrappy@1.0.2:
     optional: true

--- a/src/core/renderContextSettings.ts
+++ b/src/core/renderContextSettings.ts
@@ -17,6 +17,14 @@ export interface RenderContext {
 	releaseName: string;
 	/** Kubernetes namespace passed to `helm template --namespace` */
 	namespace: string;
+	/** Additional `-f` values files, relative to the chart directory (applied after values.yaml / values-<env>.yaml) */
+	valuesFiles?: string[];
+	/** `--set` overrides passed verbatim to `helm template` (e.g. `"image.tag=1.2.3"`) */
+	setValues?: string[];
+	/** `--api-versions` entries, for charts that branch on `.Capabilities.APIVersions` */
+	apiVersions?: string[];
+	/** `--kube-version` override, for charts that branch on `.Capabilities.KubeVersion` */
+	kubeVersion?: string;
 }
 
 /** VS Code configuration key for the render-context release name */
@@ -35,23 +43,63 @@ export const DEFAULT_NAMESPACE = "default";
 export const CHART_PROFILE_FILE = ".chart-profile.yaml";
 
 /**
- * Chart-level profile configuration schema
+ * Rendering options shared by chart-level and environment-level profile entries.
  */
-export interface ChartProfileConfig {
+export interface ChartProfileRenderOptions {
 	releaseName?: string;
 	namespace?: string;
-	environments?: Record<string, { releaseName?: string; namespace?: string }>;
+	valuesFiles?: string[];
+	setValues?: string[];
+	apiVersions?: string[];
+	kubeVersion?: string;
+}
+
+/**
+ * Chart-level profile configuration schema
+ */
+export interface ChartProfileConfig extends ChartProfileRenderOptions {
+	environments?: Record<string, ChartProfileRenderOptions>;
 }
 
 /**
  * Pure helper: build a RenderContext from raw configuration values.
  * Returns defaults when the provided values are empty / undefined.
  */
-export function buildRenderContext(releaseName: unknown, namespace: unknown): RenderContext {
-	return {
+export function buildRenderContext(
+	releaseName: unknown,
+	namespace: unknown,
+	extra?: Pick<ChartProfileRenderOptions, "valuesFiles" | "setValues" | "apiVersions" | "kubeVersion">
+): RenderContext {
+	const context: RenderContext = {
 		releaseName:
 			typeof releaseName === "string" && releaseName.trim() !== "" ? releaseName.trim() : DEFAULT_RELEASE_NAME,
 		namespace: typeof namespace === "string" && namespace.trim() !== "" ? namespace.trim() : DEFAULT_NAMESPACE,
+	};
+
+	if (extra?.valuesFiles?.length) context.valuesFiles = extra.valuesFiles;
+	if (extra?.setValues?.length) context.setValues = extra.setValues;
+	if (extra?.apiVersions?.length) context.apiVersions = extra.apiVersions;
+	if (extra?.kubeVersion) context.kubeVersion = extra.kubeVersion;
+
+	return context;
+}
+
+/** Parse an unknown YAML value into a string array, dropping non-string entries. */
+function parseStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const strings = value.filter((v): v is string => typeof v === "string" && v.trim() !== "");
+	return strings.length ? strings : undefined;
+}
+
+/** Parse a raw YAML object into a `ChartProfileRenderOptions`, ignoring malformed fields. */
+function parseRenderOptions(raw: Record<string, unknown>): ChartProfileRenderOptions {
+	return {
+		releaseName: typeof raw.releaseName === "string" ? raw.releaseName : undefined,
+		namespace: typeof raw.namespace === "string" ? raw.namespace : undefined,
+		valuesFiles: parseStringArray(raw.valuesFiles),
+		setValues: parseStringArray(raw.setValues),
+		apiVersions: parseStringArray(raw.apiVersions),
+		kubeVersion: typeof raw.kubeVersion === "string" ? raw.kubeVersion : undefined,
 	};
 }
 
@@ -66,13 +114,17 @@ export function loadChartProfile(chartPath: string): ChartProfileConfig | null {
 		const config = parseYamlAsUnknown(content);
 
 		if (config && typeof config === "object") {
+			const raw = config as Record<string, unknown>;
+			const environmentsRaw =
+				typeof raw.environments === "object" && raw.environments !== null
+					? (raw.environments as Record<string, Record<string, unknown>>)
+					: undefined;
+
 			return {
-				releaseName: typeof config.releaseName === "string" ? config.releaseName : undefined,
-				namespace: typeof config.namespace === "string" ? config.namespace : undefined,
-				environments:
-					typeof config.environments === "object" && config.environments !== null
-						? (config.environments as Record<string, { releaseName?: string; namespace?: string }>)
-						: undefined,
+				...parseRenderOptions(raw),
+				environments: environmentsRaw
+					? Object.fromEntries(Object.entries(environmentsRaw).map(([env, entry]) => [env, parseRenderOptions(entry)]))
+					: undefined,
 			};
 		}
 	} catch {
@@ -85,9 +137,9 @@ export function loadChartProfile(chartPath: string): ChartProfileConfig | null {
 /**
  * Get render context for a specific chart and environment, merging
  * workspace settings, chart profile, and defaults.
- * 
- * Precedence order (highest to lowest):
- * 1. Workspace settings
+ *
+ * Precedence order (highest to lowest), applied independently per field:
+ * 1. Workspace settings (releaseName / namespace only)
  * 2. Environment-specific profile settings
  * 3. Chart-level profile defaults
  * 4. Built-in defaults
@@ -102,18 +154,30 @@ export function getChartRenderContext(
 	const chartProfile = loadChartProfile(chartPath);
 	let releaseName = workspaceReleaseName;
 	let namespace = workspaceNamespace;
+	let valuesFiles: string[] | undefined;
+	let setValues: string[] | undefined;
+	let apiVersions: string[] | undefined;
+	let kubeVersion: string | undefined;
 
 	if (chartProfile) {
-		// Check for environment-specific overrides first (these have priority over chart defaults)
-		if (chartProfile.environments?.[environment]) {
-			const envConfig = chartProfile.environments[environment];
+		const envConfig = chartProfile.environments?.[environment];
+		// Environment-specific overrides take priority over chart-level defaults
+		if (envConfig) {
 			releaseName = releaseName ?? envConfig.releaseName;
 			namespace = namespace ?? envConfig.namespace;
+			valuesFiles = envConfig.valuesFiles;
+			setValues = envConfig.setValues;
+			apiVersions = envConfig.apiVersions;
+			kubeVersion = envConfig.kubeVersion;
 		}
 		// Apply chart-level defaults (lowest priority)
 		releaseName = releaseName ?? chartProfile.releaseName;
 		namespace = namespace ?? chartProfile.namespace;
+		valuesFiles = valuesFiles ?? chartProfile.valuesFiles;
+		setValues = setValues ?? chartProfile.setValues;
+		apiVersions = apiVersions ?? chartProfile.apiVersions;
+		kubeVersion = kubeVersion ?? chartProfile.kubeVersion;
 	}
 
-	return buildRenderContext(releaseName, namespace);
+	return buildRenderContext(releaseName, namespace, { valuesFiles, setValues, apiVersions, kubeVersion });
 }

--- a/src/k8s/helmRenderer.ts
+++ b/src/k8s/helmRenderer.ts
@@ -30,13 +30,28 @@ export interface RenderedResource {
 }
 
 /**
+ * Additional `helm template` flags sourced from the render context / chart profile.
+ */
+export interface HelmRenderOptions {
+	/** Extra `-f` values files, relative to the chart directory unless absolute */
+	valuesFiles?: string[];
+	/** `--set` overrides, passed through verbatim */
+	setValues?: string[];
+	/** `--api-versions` entries */
+	apiVersions?: string[];
+	/** `--kube-version` override */
+	kubeVersion?: string;
+}
+
+/**
  * Renders Helm templates using helm template command with full error handling and fallback rendering
  */
 export async function renderHelmTemplate(
 	chartPath: string,
 	environment: string,
 	releaseName = "chart-profile",
-	namespace = "default"
+	namespace = "default",
+	renderOptions: HelmRenderOptions = {}
 ): Promise<RenderedResource[]> {
 	// Check if helm is available
 	const helmAvailable = await isHelmAvailable();
@@ -62,6 +77,27 @@ export async function renderHelmTemplate(
 
 		if (fs.existsSync(envValuesPath)) {
 			args.push("-f", envValuesPath);
+		}
+
+		for (const extraFile of renderOptions.valuesFiles ?? []) {
+			const resolvedPath = path.isAbsolute(extraFile) ? extraFile : path.join(chartPath, extraFile);
+			if (fs.existsSync(resolvedPath)) {
+				args.push("-f", resolvedPath);
+			} else {
+				console.warn(`Configured values file not found, skipping: ${resolvedPath}`);
+			}
+		}
+
+		for (const setValue of renderOptions.setValues ?? []) {
+			args.push("--set", setValue);
+		}
+
+		for (const apiVersion of renderOptions.apiVersions ?? []) {
+			args.push("--api-versions", apiVersion);
+		}
+
+		if (renderOptions.kubeVersion) {
+			args.push("--kube-version", renderOptions.kubeVersion);
 		}
 
 		commandPreview = ["helm", ...args.map((a) => JSON.stringify(a))].join(" ");

--- a/src/k8s/kubernetesConnector.ts
+++ b/src/k8s/kubernetesConnector.ts
@@ -128,27 +128,31 @@ export class KubernetesConnector implements vscode.Disposable {
 	async getHelmReleases(namespace?: string): Promise<HelmRelease[]> {
 		try {
 			const ns = namespace || this.namespace;
-			const { stdout } = await this.runKubectl(["get", "releases", "-o", "json"], ns, {
-				timeout: TIMEOUT.DEFAULT,
-			});
+			const kubeconfigFlag = this.kubeconfig ? ["--kubeconfig", this.kubeconfig] : [];
+			const contextFlag = this.context ? ["--kube-context", this.context] : [];
+			const { stdout } = await runCommand(
+				"helm",
+				[...kubeconfigFlag, ...contextFlag, "list", "--namespace", ns, "-o", "json"],
+				{ timeout: TIMEOUT.DEFAULT }
+			);
 			const data = JSON.parse(stdout);
-			return (data.items || []).map(
+			return (Array.isArray(data) ? data : []).map(
 				(item: {
 					name?: string;
 					namespace?: string;
-					version?: string;
+					revision?: string;
 					status?: string;
 					chart?: string;
 					app_version?: string;
-					info?: { last_deployed?: string };
+					updated?: string;
 				}) => ({
 					name: item.name || "",
 					namespace: item.namespace || ns,
-					revision: item.version || "1",
+					revision: item.revision || "1",
 					status: item.status || "Unknown",
 					chart: item.chart || "",
 					appVersion: item.app_version,
-					updated: item.info?.last_deployed,
+					updated: item.updated,
 				})
 			);
 		} catch {

--- a/src/processing/chartValidator.ts
+++ b/src/processing/chartValidator.ts
@@ -49,7 +49,7 @@ export class ChartValidator {
 		let resources: RenderedResource[] = [];
 		try {
 			const renderContext = getChartContext(this.chartPath, environment);
-			resources = await renderHelmTemplate(this.chartPath, environment, renderContext.releaseName, renderContext.namespace);
+			resources = await renderHelmTemplate(this.chartPath, environment, renderContext.releaseName, renderContext.namespace, renderContext);
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			issues.push({
@@ -627,8 +627,8 @@ export class ChartValidator {
 		try {
 			const fromContext = getChartContext(this.chartPath, fromEnvironment);
 			const toContext = getChartContext(this.chartPath, toEnvironment);
-			const fromResources = await renderHelmTemplate(this.chartPath, fromEnvironment, fromContext.releaseName, fromContext.namespace);
-			const toResources = await renderHelmTemplate(this.chartPath, toEnvironment, toContext.releaseName, toContext.namespace);
+			const fromResources = await renderHelmTemplate(this.chartPath, fromEnvironment, fromContext.releaseName, fromContext.namespace, fromContext);
+			const toResources = await renderHelmTemplate(this.chartPath, toEnvironment, toContext.releaseName, toContext.namespace, toContext);
 
 			const connector = getKubernetesConnector();
 

--- a/src/state/runtimeStateManager.ts
+++ b/src/state/runtimeStateManager.ts
@@ -112,7 +112,7 @@ export class RuntimeStateManager {
 		// Render chart to get expected resources
 		try {
 			const renderContext = getChartContext(chartPath, environment);
-			const renderedResources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
+			const renderedResources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace, renderContext);
 
 			// Get runtime state for each resource
 			for (const resource of renderedResources) {
@@ -303,7 +303,7 @@ export class RuntimeStateManager {
 
 		// Get rendered resource with chart-specific context
 		const renderContext = getChartContext(chartPath, environment);
-		const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
+		const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace, renderContext);
 		const resource = resources.find((r) => r.kind === kind && r.name === name);
 
 		const rendered = resource?.yaml || "";

--- a/src/utils/renderedYamlView.ts
+++ b/src/utils/renderedYamlView.ts
@@ -112,7 +112,7 @@ async function showRenderedTemplates(chartPath: string, environment: string, cha
 
 			// Render templates using chart-specific context
 			const renderContext = getChartContext(chartPath, environment);
-			const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
+			const resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace, renderContext);
 
 			progress.report({ increment: 50 });
 

--- a/src/visualization/chartVisualizationView.ts
+++ b/src/visualization/chartVisualizationView.ts
@@ -614,8 +614,8 @@ async function handleMessage(message: WebviewMessage) {
 
 					const renderContext1 = getChartContext(chartPath, leftEnv);
 					const renderContext2 = getChartContext(chartPath, rightEnv);
-					const resources1 = await renderHelmTemplate(chartPath, leftEnv, renderContext1.releaseName, renderContext1.namespace);
-					const resources2 = await renderHelmTemplate(chartPath, rightEnv, renderContext2.releaseName, renderContext2.namespace);
+					const resources1 = await renderHelmTemplate(chartPath, leftEnv, renderContext1.releaseName, renderContext1.namespace, renderContext1);
+					const resources2 = await renderHelmTemplate(chartPath, rightEnv, renderContext2.releaseName, renderContext2.namespace, renderContext2);
 
 					const comparison = compareEnvironments(leftEnv, resources1, rightEnv, resources2, chartName);
 					const comparisonData = formatComparisonForWebview(comparison);
@@ -694,8 +694,8 @@ async function runComparisonFromWebview(env1: string, env2: string): Promise<voi
 
 		const renderContext1 = getChartContext(chartPath, env1);
 		const renderContext2 = getChartContext(chartPath, env2);
-		const resources1 = await renderHelmTemplate(chartPath, env1, renderContext1.releaseName, renderContext1.namespace);
-		const resources2 = await renderHelmTemplate(chartPath, env2, renderContext2.releaseName, renderContext2.namespace);
+		const resources1 = await renderHelmTemplate(chartPath, env1, renderContext1.releaseName, renderContext1.namespace, renderContext1);
+		const resources2 = await renderHelmTemplate(chartPath, env2, renderContext2.releaseName, renderContext2.namespace, renderContext2);
 
 		const comparison = compareEnvironments(env1, resources1, env2, resources2, chartName);
 		const comparisonData = formatComparisonForWebview(comparison);
@@ -1116,7 +1116,7 @@ async function collectChartDataCore(params: CollectChartDataParams): Promise<{
 
 	try {
 		const renderContext = getChartContext(chartPath, environment);
-		resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace);
+		resources = await renderHelmTemplate(chartPath, environment, renderContext.releaseName, renderContext.namespace, renderContext);
 		renderedResources = resources;
 
 		resources.forEach((resource) => {

--- a/test/renderContext.test.js
+++ b/test/renderContext.test.js
@@ -34,6 +34,7 @@ function test(name, fn) {
 		passed++;
 	} catch (err) {
 		console.error(`  ✘ ${name}`);
+		// @ts-ignore
 		console.error(`      ${err.message}`);
 		failed++;
 	}
@@ -152,7 +153,9 @@ test("loadChartProfile parses valid chart profile", () => {
 	fs.writeFileSync(profilePath, "releaseName: my-release\nnamespace: my-namespace\n");
 
 	const profile = loadChartProfile(tempDir);
+	// @ts-ignore
 	assert.strictEqual(profile.releaseName, "my-release");
+	// @ts-ignore
 	assert.strictEqual(profile.namespace, "my-namespace");
 
 	fs.rmSync(tempDir, { recursive: true });
@@ -174,10 +177,15 @@ environments:
 `);
 
 	const profile = loadChartProfile(tempDir);
+	// @ts-ignore
 	assert.strictEqual(profile.releaseName, "default-release");
+	// @ts-ignore
 	assert.strictEqual(profile.namespace, "default-ns");
+	// @ts-ignore
 	assert.strictEqual(profile.environments.dev.releaseName, "dev-release");
+	// @ts-ignore
 	assert.strictEqual(profile.environments.dev.namespace, "dev-ns");
+	// @ts-ignore
 	assert.strictEqual(profile.environments.prod.releaseName, "prod-release");
 
 	fs.rmSync(tempDir, { recursive: true });
@@ -231,6 +239,142 @@ test("getChartRenderContext workspace settings take precedence over chart defaul
 	const ctx = getChartRenderContext("workspace-release", undefined, tempDir, "dev");
 	assert.strictEqual(ctx.releaseName, "workspace-release");
 	assert.strictEqual(ctx.namespace, "chart-ns");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext applies chart defaults for unmatched environment", () => {
+	const tempDir = path.join(__dirname, "temp-profile-default-env-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, `
+releaseName: default-release
+namespace: default-ns
+environments:
+  dev:
+    releaseName: dev-release
+`);
+
+	// When environment is "default" (not in profile), chart-level defaults should apply
+	const ctx = getChartRenderContext(undefined, undefined, tempDir, "default");
+	assert.strictEqual(ctx.releaseName, "default-release");
+	assert.strictEqual(ctx.namespace, "default-ns");
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+// ── Rendering fidelity options (valuesFiles / setValues / apiVersions / kubeVersion) ──
+
+console.log("\nRendering fidelity options:");
+
+test("buildRenderContext omits empty extra fields", () => {
+	const ctx = buildRenderContext("my-release", "default", {});
+	assert.strictEqual(ctx.valuesFiles, undefined);
+	assert.strictEqual(ctx.setValues, undefined);
+	assert.strictEqual(ctx.apiVersions, undefined);
+	assert.strictEqual(ctx.kubeVersion, undefined);
+});
+
+test("buildRenderContext carries through non-empty extra fields", () => {
+	const ctx = buildRenderContext("my-release", "default", {
+		valuesFiles: ["values-common.yaml"],
+		setValues: ["image.tag=1.2.3"],
+		apiVersions: ["networking.k8s.io/v1/Ingress"],
+		kubeVersion: "1.29.0",
+	});
+	assert.deepStrictEqual(ctx.valuesFiles, ["values-common.yaml"]);
+	assert.deepStrictEqual(ctx.setValues, ["image.tag=1.2.3"]);
+	assert.deepStrictEqual(ctx.apiVersions, ["networking.k8s.io/v1/Ingress"]);
+	assert.strictEqual(ctx.kubeVersion, "1.29.0");
+});
+
+test("loadChartProfile parses valuesFiles/setValues/apiVersions/kubeVersion", () => {
+	const tempDir = path.join(__dirname, "temp-profile-fidelity-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(
+		profilePath,
+		`
+releaseName: my-app
+namespace: my-app
+valuesFiles:
+  - values-common.yaml
+setValues:
+  - "global.region=us-east"
+apiVersions:
+  - "networking.k8s.io/v1/Ingress"
+kubeVersion: "1.29.0"
+environments:
+  dev:
+    setValues:
+      - "replicaCount=1"
+`
+	);
+
+	const profile = loadChartProfile(tempDir);
+	assert.deepStrictEqual(profile.valuesFiles, ["values-common.yaml"]);
+	assert.deepStrictEqual(profile.setValues, ["global.region=us-east"]);
+	assert.deepStrictEqual(profile.apiVersions, ["networking.k8s.io/v1/Ingress"]);
+	assert.strictEqual(profile.kubeVersion, "1.29.0");
+	assert.deepStrictEqual(profile.environments.dev.setValues, ["replicaCount=1"]);
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("loadChartProfile drops non-string array entries", () => {
+	const tempDir = path.join(__dirname, "temp-profile-fidelity-invalid-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(profilePath, "setValues:\n  - 1\n  - true\n");
+
+	const profile = loadChartProfile(tempDir);
+	assert.strictEqual(profile.setValues, undefined);
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext falls back to chart-level fidelity options when environment has none", () => {
+	const tempDir = path.join(__dirname, "temp-profile-fidelity-fallback-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(
+		profilePath,
+		`
+releaseName: my-app
+namespace: my-app
+valuesFiles:
+  - values-common.yaml
+environments:
+  dev:
+    releaseName: my-app-dev
+`
+	);
+
+	const ctx = getChartRenderContext(undefined, undefined, tempDir, "dev");
+	assert.strictEqual(ctx.releaseName, "my-app-dev");
+	assert.deepStrictEqual(ctx.valuesFiles, ["values-common.yaml"]);
+
+	fs.rmSync(tempDir, { recursive: true });
+});
+
+test("getChartRenderContext prefers environment-specific fidelity options over chart-level", () => {
+	const tempDir = path.join(__dirname, "temp-profile-fidelity-env-test");
+	fs.mkdirSync(tempDir, { recursive: true });
+	const profilePath = path.join(tempDir, ".chart-profile.yaml");
+	fs.writeFileSync(
+		profilePath,
+		`
+setValues:
+  - "global.region=us-east"
+environments:
+  dev:
+    setValues:
+      - "replicaCount=1"
+`
+	);
+
+	const ctx = getChartRenderContext(undefined, undefined, tempDir, "dev");
+	assert.deepStrictEqual(ctx.setValues, ["replicaCount=1"]);
 
 	fs.rmSync(tempDir, { recursive: true });
 });


### PR DESCRIPTION
## Summary
- Fix `getHelmReleases()` calling a non-existent `kubectl get releases` resource. it now shells out to `helm list` correctly, so runtime-state/cluster-status views can actually report installed releases.
- Extend `.chart-profile.yaml` / `RenderContext` with `valuesFiles`, `setValues`, `apiVersions`, and `kubeVersion` so `helm template` renders can include extra value overlays, `--set` overrides, and `.Capabilities`-gated templates — previously these were silently unsupported, which could produce incomplete or incorrect rendered output for non-trivial charts.
- Both fields are configurable at chart-level and per-environment in `.chart-profile.yaml`, following the same override precedence as `releaseName`/`namespace`.